### PR TITLE
fix: waitOn uses reverse to ensure server has started on port

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -47,7 +47,8 @@ function startAndTest ({ start, url, test }) {
         interval: 2000,
         window: 1000,
         verbose: isDebug(),
-        log: isDebug()
+        log: isDebug(),
+        reverse: true
       },
       err => {
         if (err) {


### PR DESCRIPTION
Thank you for a great utility! waitOn currently waits for the port to be available. I believe the expected behavior should be for waitOn to ensure that the server has been created and the port is occupied.