### PR TITLE
Support waiting on multiple resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,18 @@ You can provide port number and custom test command, in that case `npm start` is
 }
 ```
 
+You can provide multiple resources to wait on, separated by a pipe `|`. _(be sure to wrap in quotes)_
+
+```json
+{
+    "scripts": {
+        "start": "npm start",
+        "test-it": "mocha e2e-spec.js",
+        "ci": "server-test \"8080|http://foo.com\""
+    }
+}
+```
+
 ## Note for webpack-dev-server users
 
 If you are using [webpack-dev-server](https://www.npmjs.com/package/webpack-dev-server) (directly or via `angular/cli` or other boilerplates) then please use the following URL form to check

--- a/package.json
+++ b/package.json
@@ -75,7 +75,9 @@
     "semantic-release": "semantic-release",
     "start": "node test/server.js",
     "start-with-child": "node test/server-as-child.js",
+    "start-multiple": "node test/multiple-servers.js",
     "test2": "curl http://127.0.0.1:9000",
+    "test3": "curl http://127.0.0.1:9000 && curl http://127.0.0.1:9001",
     "demo": "node bin/start.js http://127.0.0.1:9000",
     "demo2": "node bin/start.js start http://127.0.0.1:9000 test2",
     "demo3": "node bin/start.js start-with-child http://127.0.0.1:9000 test",
@@ -83,6 +85,7 @@
     "demo5": "node bin/start.js start-with-child 9000",
     "demo6": "node bin/start.js :9000",
     "demo7": "node bin/start.js :9000 test2",
+    "demo8": "node bin/start.js start-multiple \":9000|:9001\" test3",
     "travis-deploy-once": "travis-deploy-once"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,11 @@ const isDebug = () =>
 function startAndTest ({ start, url, test }) {
   la(is.unemptyString(start), 'missing start script name', start)
   la(is.unemptyString(test), 'missing test script name', test)
-  la(is.unemptyString(url), 'missing url to wait on', url)
+  la(
+    is.unemptyString(url) || is.unemptyArray(url),
+    'missing url to wait on',
+    url
+  )
 
   debug('starting server, verbose mode?', isDebug())
 
@@ -43,7 +47,7 @@ function startAndTest ({ start, url, test }) {
     debug('starting waitOn %s', url)
     waitOn(
       {
-        resources: [url],
+        resources: Array.isArray(url) ? url : [url],
         interval: 2000,
         window: 1000,
         verbose: isDebug(),

--- a/src/start-server-and-test-spec.js
+++ b/src/start-server-and-test-spec.js
@@ -4,6 +4,10 @@
 const startServerAndTest = require('.')
 const la = require('lazy-ass')
 
+function arrayEq (a, b) {
+  return a.length === b.length && a.every((el, index) => el === b[index])
+}
+
 describe('start-server-and-test', () => {
   it('write this test', () => {
     console.assert(startServerAndTest, 'should export something')
@@ -31,28 +35,49 @@ describe('utils', () => {
     it('allows :port string', () => {
       la(isUrlOrPort(':6006'))
     })
+
+    it('allows multiple resources', () => {
+      la(isUrlOrPort('http://localhost|http://foo.com'))
+    })
+
+    it('detects invalid resource when using multiple', () => {
+      la(!isUrlOrPort('http://localhost|http://foo.com|_+9'))
+    })
   })
 
   context('normalizeUrl', () => {
     const normalizeUrl = utils.normalizeUrl
 
     it('passes url', () => {
-      la(normalizeUrl('http://localhost') === 'http://localhost')
-      la(normalizeUrl('http://localhost:6000') === 'http://localhost:6000')
+      la(arrayEq(normalizeUrl('http://localhost'), ['http://localhost']))
+      la(
+        arrayEq(normalizeUrl('http://localhost:6000'), [
+          'http://localhost:6000'
+        ])
+      )
     })
 
     it('changes port to localhost', () => {
-      la(normalizeUrl('6006') === 'http://localhost:6006')
-      la(normalizeUrl(8080) === 'http://localhost:8080')
+      la(arrayEq(normalizeUrl('6006'), ['http://localhost:6006']))
+      la(arrayEq(normalizeUrl(8080), ['http://localhost:8080']))
     })
 
     it('changes :port to localhost', () => {
-      la(normalizeUrl(':6006') === 'http://localhost:6006')
+      la(arrayEq(normalizeUrl(':6006'), ['http://localhost:6006']))
     })
 
     it('returns original argument if does not know what to do', () => {
-      la(normalizeUrl('foo') === 'foo', normalizeUrl('foo'))
-      la(normalizeUrl(808000) === 808000, normalizeUrl(808000))
+      la(arrayEq(normalizeUrl('foo'), ['foo']), normalizeUrl('foo'))
+      la(arrayEq(normalizeUrl(808000), [808000]), normalizeUrl(808000))
+    })
+
+    it('parses multiple resources', () => {
+      la(
+        arrayEq(normalizeUrl(':6006|http://foo.com'), [
+          'http://localhost:6006',
+          'http://foo.com'
+        ])
+      )
     })
   })
 })

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,44 +1,52 @@
 const is = require('check-more-types')
 
-const isUrlOrPort = s => {
-  if (is.url(s)) {
-    return s
-  }
-  if (is.number(s)) {
-    return is.port(s)
-  }
-  if (!is.string(s)) {
-    return false
-  }
-  if (s[0] === ':') {
-    const withoutColon = s.substr(1)
-    return is.port(parseInt(withoutColon))
-  }
-  return is.port(parseInt(s))
+const isUrlOrPort = input => {
+  const str = is.string(input) ? input.split('|') : [input]
+
+  return str.every(s => {
+    if (is.url(s)) {
+      return s
+    }
+    if (is.number(s)) {
+      return is.port(s)
+    }
+    if (!is.string(s)) {
+      return false
+    }
+    if (s[0] === ':') {
+      const withoutColon = s.substr(1)
+      return is.port(parseInt(withoutColon))
+    }
+    return is.port(parseInt(s))
+  })
 }
 
-const normalizeUrl = s => {
-  if (is.url(s)) {
+const normalizeUrl = input => {
+  const str = is.string(input) ? input.split('|') : [input]
+
+  return str.map(s => {
+    if (is.url(s)) {
+      return s
+    }
+
+    if (is.number(s) && is.port(s)) {
+      return `http://localhost:${s}`
+    }
+
+    if (!is.string(s)) {
+      return s
+    }
+
+    if (is.port(parseInt(s))) {
+      return `http://localhost:${s}`
+    }
+
+    if (s[0] === ':') {
+      return `http://localhost${s}`
+    }
+    // for anything else, return original argument
     return s
-  }
-
-  if (is.number(s) && is.port(s)) {
-    return `http://localhost:${s}`
-  }
-
-  if (!is.string(s)) {
-    return s
-  }
-
-  if (is.port(parseInt(s))) {
-    return `http://localhost:${s}`
-  }
-
-  if (s[0] === ':') {
-    return `http://localhost${s}`
-  }
-  // for anything else, return original argument
-  return s
+  })
 }
 
 module.exports = {

--- a/test/multiple-servers.js
+++ b/test/multiple-servers.js
@@ -1,0 +1,28 @@
+const http = require('http');
+const server = http.createServer((req, res) => {
+  console.log(req.method)
+  if (req.method === 'GET') {
+    res.end('Server 1 is good!\n\n')
+  } else {
+    res.end();
+  }
+});
+setTimeout(() => {
+  server.listen(9000)
+  console.log('listening at port 9000')
+}, 1000)
+
+const server2 = http.createServer((req, res) => {
+  console.log(req.method)
+  if (req.method === 'GET') {
+    res.end('Server 2 is good!\n\n')
+  } else {
+    res.end();
+  }
+});
+setTimeout(() => {
+  server2.listen(9001)
+  console.log('listening at port 9001')
+}, 5000)
+
+console.log('sleeping for 5 seconds before starting')


### PR DESCRIPTION
Enables things such as:

```json
{
  "scripts": {
    "start": "concurrently \"node start-database.js\" \"node server.js\"",
    "test": "cypress run",
    "ci": "start-server-and-test \"http-get://localhost:8080|:3000\""
  }
}
```

(Where a database server might be responding to GET requests on port `8080`, and an app webserver is running on port `3000`)

PS: a lot of the diff is whitespace, it's easier to read [with whitespace diff disabled](https://github.com/bahmutov/start-server-and-test/pull/65/files?w=1).