### PR TITLE
feat: Allow passing arguments to test script (issue #88)

### DIFF
--- a/bin/start.js
+++ b/bin/start.js
@@ -28,7 +28,7 @@ if (args.length === 1 && utils.isUrlOrPort(args[0])) {
 } else {
   start = args[0]
   url = utils.normalizeUrl(args[1])
-  test = args[3] ? [args[2]].concat(['--']).concat(args.slice(3)) : [args[2]]
+  test = utils.parseExtraArgs(args)
 }
 
 console.log(`starting server using command "npm run ${start}"`)

--- a/bin/start.js
+++ b/bin/start.js
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 
 const args = process.argv.slice(2)
-const la = require('lazy-ass')
 const startAndTest = require('..')
 const utils = require('../src/utils')
 
@@ -27,15 +26,14 @@ if (args.length === 1 && utils.isUrlOrPort(args[0])) {
     url = utils.normalizeUrl(args[1])
   }
 } else {
-  la(args.length === 3, 'expect: <start script name> <url> <test script name>')
   start = args[0]
   url = utils.normalizeUrl(args[1])
-  test = args[2]
+  test = args[3] ? [args[2]].concat(['--']).concat(args.slice(3)) : [args[2]]
 }
 
 console.log(`starting server using command "npm run ${start}"`)
 console.log(`and when url "${url}" is responding`)
-console.log(`running tests using command "${test}"`)
+console.log(`running tests using command "${test.join(' ')}"`)
 
 startAndTest({ start, url, test }).catch(e => {
   console.error(e)

--- a/package-lock.json
+++ b/package-lock.json
@@ -495,7 +495,6 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
-      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -507,7 +506,6 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
-          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ const isInsecure = () => process.env.START_SERVER_AND_TEST_INSECURE
 
 function startAndTest ({ start, url, test }) {
   la(is.unemptyString(start), 'missing start script name', start)
-  la(is.unemptyString(test), 'missing test script name', test)
+  la(is.arrayOfStrings(test), 'missing test script name and arguments', test)
   la(
     is.unemptyString(url) || is.unemptyArray(url),
     'missing url to wait on',
@@ -70,7 +70,7 @@ function startAndTest ({ start, url, test }) {
 
   function runTests () {
     debug('running test script command', test)
-    return execa('npm', ['run', test], { stdio: 'inherit' })
+    return execa('npm', ['run'].concat(test), { stdio: 'inherit' })
   }
 
   return waited

--- a/src/start-server-and-test-spec.js
+++ b/src/start-server-and-test-spec.js
@@ -80,4 +80,51 @@ describe('utils', () => {
       )
     })
   })
+
+  context('parseExtraArgs', () => {
+    const parseExtraArgs = utils.parseExtraArgs
+    const baseArgs = ['arg1', 'arg2', 'arg3']
+
+    it('does not require arguments', () => {
+      la(arrayEq(parseExtraArgs(baseArgs), ['arg3']))
+    })
+
+    it('passes double "--" on to test script', () => {
+      la(
+        arrayEq(parseExtraArgs(baseArgs.concat(['--', 'something'])), [
+          'arg3',
+          '--',
+          '--',
+          'something'
+        ])
+      )
+    })
+
+    it('can pass multiple arguments', () => {
+      la(
+        arrayEq(
+          parseExtraArgs(
+            baseArgs.concat([
+              '--',
+              '--tag',
+              '-d',
+              '--format',
+              '"something"',
+              'file.txt'
+            ])
+          ),
+          [
+            'arg3',
+            '--',
+            '--',
+            '--tag',
+            '-d',
+            '--format',
+            '"something"',
+            'file.txt'
+          ]
+        )
+      )
+    })
+  })
 })

--- a/src/utils.js
+++ b/src/utils.js
@@ -49,7 +49,16 @@ const normalizeUrl = input => {
   })
 }
 
+const parseExtraArgs = args => {
+  if (args[3]) {
+    return [args[2]].concat(['--']).concat(args.slice(3))
+  } else {
+    return [args[2]]
+  }
+}
+
 module.exports = {
   isUrlOrPort: isUrlOrPort,
-  normalizeUrl: normalizeUrl
+  normalizeUrl: normalizeUrl,
+  parseExtraArgs: parseExtraArgs
 }


### PR DESCRIPTION
As per issue #88 

Background: Recently the npm repo `cucumber-nightwatch` was deprecated in favour of `nightwatch-api`, whose example for how to use CucumberJs with Nightwatch involves using `start-server-and-test`. What the example does not account for that `cucumber-nightwatch` supported though was passing arguments to Cucumber for tags, targeting feature files, etc.

This limitation was due to the passing-arguments feature not yet implemented in `start-server-and-test`. I'm currently working on a project where we need to update nightwatch to a version that the old `cucumber-nightwatch` does not support, so I needed something that works and took on this issue.

Their example: https://github.com/mucsi96/nightwatch-api/tree/master/examples/cucumber
I opened an issue on their end as well: https://github.com/mucsi96/nightwatch-api/issues/24

I've tried my best to copy the style of the repo, hopefully it is up to par!

Usage:

Assuming:

```json
{
    "test": "start-server-and-test test:setup http-get://localhost:4444 test:run",
    "test:run": "my-test-runner",
    "test:setup": "my-server-setup",
}
```

```bash
npm run test -- --tag mytag
```

would pass `-- --tag mytag` to the `test:run` script, which would run `my-test-runner --tag mytag`.

I've kept in the convention of `--` as a requirement for this to run correctly as it seems to be how passing arguments to other scripts is typically handled. There's other ways to do this as well, but this is what better matched what we had previously.

Thanks for this repo!