### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ## Install
 
-Requires [Node](https://nodejs.org/en/) version 6 or above.
+Requires [Node](https://nodejs.org/en/) version 8.9 or above.
 
 ```sh
 npm install --save-dev start-server-and-test


### PR DESCRIPTION
The wait-on module upgraded their dependency on joi and joi forced the update to Node 8.9 for TLS. So this module fails to install unless you're on Node 8.9 or greater.