### PR TITLE
fix: send SIGINT to child processes instead of SIGKILL, fixes #71

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -36,7 +36,7 @@ function startAndTest ({ start, url, test }) {
           debug('stopping child processes')
           children.forEach(child => {
             try {
-              process.kill(child.PID)
+              process.kill(child.PID, 'SIGINT')
             } catch (e) {
               if (e.code === 'ESRCH') {
                 console.log(`Child process ${child.PID} exited before trying to stop it`)


### PR DESCRIPTION
See https://github.com/bahmutov/start-server-and-test/issues/71#issuecomment-440133682

- closes #71 