### PR TITLE
feat: custom commands

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ script:
   - npm run demo7
   - START_SERVER_AND_TEST_INSECURE=1 npm run demo9
   - npm run demo-cross-env
+  - npm run demo-commands
 after_success:
   - npm run travis-deploy-once "npm run semantic-release"
 branches:

--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ This command is meant to be used with NPM script commands. If you have a "start 
 
 To execute all tests simply run `npm run ci`
 
+### Commands
+
+In addition to using NPM script names, you can pass entire commands (surround them with quotes so it is still a single string) that will be executed "as is". For example, to start globally installed `http-server` before running and recording [Cypress.io](https://www.cypress.io) tests you can use
+
+```
+start-server-and-test 'http-server -c-1 --silent' 8000 './node_modules/.bin/cypress run --record'
+```
+
 ### Alias
 
 You can use either `start-server-and-test`, `server-test` or `start-test` commands in your scripts.
@@ -109,6 +117,8 @@ You can provide multiple resources to wait on, separated by a pipe `|`. _(be sur
     }
 }
 ```
+
+or for multiple ports simply: `server-test '8000|9000' test`.
 
 ## Note for webpack-dev-server users
 

--- a/__snapshots__/utils-spec.js
+++ b/__snapshots__/utils-spec.js
@@ -1,51 +1,59 @@
 exports['utils getArguments handles 3 arguments with http-get url 1'] = {
-  "start": "start",
+  "start": "npm run start",
   "url": [
     "http-get://localhost:8080"
   ],
-  "test": "test"
+  "test": "npm run test"
 }
 
 exports['utils getArguments returns 3 arguments 1'] = {
-  "start": "start",
+  "start": "npm run start",
   "url": [
     "http://localhost:8080"
   ],
-  "test": "test"
+  "test": "npm run test"
 }
 
 exports['utils getArguments returns 3 arguments with url 1'] = {
-  "start": "start",
+  "start": "npm run start",
   "url": [
     "http://localhost:8080"
   ],
-  "test": "test"
+  "test": "npm run test"
+}
+
+exports['utils getArguments understands custom commands 1'] = {
+  "start": "custom-command --with argument",
+  "url": [
+    "http://localhost:3000"
+  ],
+  "test": "test-command --x=1"
 }
 
 exports['utils getArguments understands several ports 1'] = {
-  "start": "start",
+  "start": "npm run start",
   "url": [
     "http://localhost:3000",
     "http://localhost:4000",
     "http://localhost:5000"
   ],
-  "test": "test"
+  "test": "npm run test"
 }
 
 exports['utils getArguments understands single :port 1'] = {
-  "start": "start",
+  "start": "npm run start",
   "url": [
     "http://localhost:3000"
   ],
-  "test": "test"
+  "test": "npm run test"
 }
 
 exports['utils getArguments understands single port 1'] = {
-  "start": "start",
+  "start": "npm run start",
   "url": [
     "http://localhost:3000"
   ],
-  "test": "test"
+  "test": "npm run test"
 }
 
 exports['utils getArguments understands start plus url 1'] = {
@@ -53,13 +61,13 @@ exports['utils getArguments understands start plus url 1'] = {
   "url": [
     "http://localhost:6000"
   ],
-  "test": "test"
+  "test": "npm run test"
 }
 
 exports['utils getArguments understands url plus test 1'] = {
-  "start": "start",
+  "start": "npm run start",
   "url": [
     "http://localhost:6000"
   ],
-  "test": "test"
+  "test": "npm run test"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3454,9 +3454,9 @@
       "dev": true
     },
     "capture-stack-trace": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
-      "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz",
+      "integrity": "sha512-mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw==",
       "dev": true
     },
     "cardinal": {
@@ -6355,22 +6355,63 @@
       }
     },
     "got": {
-      "version": "6.7.1",
-      "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
-      "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
+      "integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
       "dev": true,
       "requires": {
-        "create-error-class": "^3.0.0",
+        "@sindresorhus/is": "^0.14.0",
+        "@szmarczak/http-timer": "^1.1.2",
+        "cacheable-request": "^6.0.0",
+        "decompress-response": "^3.3.0",
         "duplexer3": "^0.1.4",
-        "get-stream": "^3.0.0",
-        "is-redirect": "^1.0.0",
-        "is-retry-allowed": "^1.0.0",
-        "is-stream": "^1.0.0",
-        "lowercase-keys": "^1.0.0",
-        "safe-buffer": "^5.0.1",
-        "timed-out": "^4.0.0",
-        "unzip-response": "^2.0.1",
-        "url-parse-lax": "^1.0.0"
+        "get-stream": "^4.1.0",
+        "lowercase-keys": "^1.0.1",
+        "mimic-response": "^1.0.1",
+        "p-cancelable": "^1.0.0",
+        "to-readable-stream": "^1.0.0",
+        "url-parse-lax": "^3.0.0"
+      },
+      "dependencies": {
+        "@sindresorhus/is": {
+          "version": "0.14.0",
+          "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
+          "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
+          "dev": true
+        },
+        "@szmarczak/http-timer": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
+          "integrity": "sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==",
+          "dev": true,
+          "requires": {
+            "defer-to-connect": "^1.0.1"
+          }
+        },
+        "cacheable-request": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.0.0.tgz",
+          "integrity": "sha512-2N7AmszH/WPPpl5Z3XMw1HAP+8d+xugnKQAeKvxFZ/04dbT/CAznqwbl+7eSr3HkwdepNwtb2yx3CAMQWvG01Q==",
+          "dev": true,
+          "requires": {
+            "clone-response": "^1.0.2",
+            "get-stream": "^4.0.0",
+            "http-cache-semantics": "^4.0.0",
+            "keyv": "^3.0.0",
+            "lowercase-keys": "^1.0.1",
+            "normalize-url": "^3.1.0",
+            "responselike": "^1.0.2"
+          }
+        },
+        "get-stream": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        }
       }
     },
     "graceful-fs": {
@@ -12495,6 +12536,42 @@
         "registry-auth-token": "^3.0.1",
         "registry-url": "^3.0.3",
         "semver": "^5.1.0"
+      },
+      "dependencies": {
+        "got": {
+          "version": "6.7.1",
+          "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
+          "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
+          "dev": true,
+          "requires": {
+            "create-error-class": "^3.0.0",
+            "duplexer3": "^0.1.4",
+            "get-stream": "^3.0.0",
+            "is-redirect": "^1.0.0",
+            "is-retry-allowed": "^1.0.0",
+            "is-stream": "^1.0.0",
+            "lowercase-keys": "^1.0.0",
+            "safe-buffer": "^5.0.1",
+            "timed-out": "^4.0.0",
+            "unzip-response": "^2.0.1",
+            "url-parse-lax": "^1.0.0"
+          }
+        },
+        "prepend-http": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+          "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
+          "dev": true
+        },
+        "url-parse-lax": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+          "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+          "dev": true,
+          "requires": {
+            "prepend-http": "^1.0.1"
+          }
+        }
       }
     },
     "parse-github-url": {
@@ -13054,9 +13131,9 @@
       "dev": true
     },
     "prepend-http": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-      "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
+      "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
       "dev": true
     },
     "prettier": {
@@ -15680,12 +15757,12 @@
       "dev": true
     },
     "url-parse-lax": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
-      "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
+      "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
       "dev": true,
       "requires": {
-        "prepend-http": "^1.0.1"
+        "prepend-http": "^2.0.0"
       }
     },
     "url-template": {

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "demo9": "node src/bin/start.js start-https \"https://127.0.0.1:9000\" test4",
     "demo10": "node src/bin/start.js start-fail http://127.0.0.1:9000 test",
     "demo-cross-env": "node src/bin/start.js start-cross-env 9000",
-    "demo-commands": "node src/bin/start.js 'node test/server.js' 9000 'npm run unit'",
+    "demo-commands": "node src/bin/start.js 'node test/server.js --port 8800' 8800 'npm run unit'",
     "travis-deploy-once": "travis-deploy-once"
   },
   "devDependencies": {
@@ -99,6 +99,7 @@
     "dont-crack": "1.2.1",
     "git-issues": "1.3.1",
     "license-checker": "24.1.0",
+    "minimist": "1.2.0",
     "mocha": "6.1.4",
     "pre-git": "3.17.1",
     "prettier-standard": "8.0.1",

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "demo9": "node src/bin/start.js start-https \"https://127.0.0.1:9000\" test4",
     "demo10": "node src/bin/start.js start-fail http://127.0.0.1:9000 test",
     "demo-cross-env": "node src/bin/start.js start-cross-env 9000",
+    "demo-commands": "node src/bin/start.js 'node test/server.js' 9000 'npm run unit'",
     "travis-deploy-once": "travis-deploy-once"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "demo9": "node src/bin/start.js start-https \"https://127.0.0.1:9000\" test4",
     "demo10": "node src/bin/start.js start-fail http://127.0.0.1:9000 test",
     "demo-cross-env": "node src/bin/start.js start-cross-env 9000",
-    "demo-commands": "node src/bin/start.js 'node test/server.js --port 8800' 8800 'npm run unit'",
+    "demo-commands": "node src/bin/start.js 'node test/server.js --port 8800' 8800 'node test/client --port 8800'",
     "travis-deploy-once": "travis-deploy-once"
   },
   "devDependencies": {
@@ -98,6 +98,7 @@
     "deps-ok": "1.4.1",
     "dont-crack": "1.2.1",
     "git-issues": "1.3.1",
+    "got": "9.6.0",
     "license-checker": "24.1.0",
     "minimist": "1.2.0",
     "mocha": "6.1.4",

--- a/src/bin/start.js
+++ b/src/bin/start.js
@@ -6,9 +6,9 @@ const utils = require('../utils')
 
 const { start, test, url } = utils.getArguments(args)
 
-console.log(`starting server using command "npm run ${start}"`)
-console.log(`and when url "${url}" is responding`)
-console.log(`running tests using command "npm run ${test}"`)
+console.log('starting server using command "%s"', start)
+console.log('and when url "%s" is responding', url)
+console.log('running tests using command "%s"', test)
 
 startAndTest({ start, url, test }).catch(e => {
   console.error(e)

--- a/src/index.js
+++ b/src/index.js
@@ -22,10 +22,9 @@ function startAndTest ({ start, url, test }) {
     url
   )
 
-  debug('starting server, verbose mode?', isDebug())
+  debug('starting server with command "%s", verbose mode?', start, isDebug())
 
-  const startCommand = 'npm run start'
-  const server = execa.shell(startCommand, { stdio: 'inherit' })
+  const server = execa.shell(start, { stdio: 'inherit' })
   let serverStopped
 
   function stopServer () {
@@ -87,9 +86,8 @@ function startAndTest ({ start, url, test }) {
   })
 
   function runTests () {
-    const testCommand = `npm run ${test}`
-    debug('running test script command: %s', testCommand)
-    return execa.shell(testCommand, { stdio: 'inherit' })
+    debug('running test script command: %s', test)
+    return execa.shell(test, { stdio: 'inherit' })
   }
 
   return waited

--- a/src/utils-spec.js
+++ b/src/utils-spec.js
@@ -45,6 +45,8 @@ describe('utils', () => {
     })
 
     it('understands start plus url', () => {
+      // note that this script "start-server" does not exist
+      // thus it is left as is - without "npm run" part
       snapshot(getArguments(['start-server', '6000']))
     })
 
@@ -58,6 +60,18 @@ describe('utils', () => {
 
     it('understands several ports', () => {
       snapshot(getArguments(['3000|4000|5000']))
+    })
+
+    it('understands custom commands', () => {
+      // these commands are NOT script names in the package.json
+      // thus they will be run as is
+      snapshot(
+        getArguments([
+          'custom-command --with argument',
+          '3000',
+          'test-command --x=1'
+        ])
+      )
     })
   })
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -43,6 +43,14 @@ const getArguments = cliArgs => {
     test = cliArgs[2]
   }
 
+  if (isPackageScriptName(start)) {
+    start = `npm run ${start}`
+  }
+
+  if (isPackageScriptName(test)) {
+    test = `npm run ${test}`
+  }
+
   return {
     start,
     url,

--- a/test/client.js
+++ b/test/client.js
@@ -1,0 +1,17 @@
+// little test client to ping server at a given port
+const argv = require('minimist')(process.argv.slice(2), {
+  alias: {
+    port: 'p'
+  }
+})
+const port = argv.port || 9000
+const got = require('got')
+const url = `http://localhost:${port}`
+got(url)
+  .then(() => {
+    console.log('url %s has responded 👍', url)
+  })
+  .catch(e => {
+    console.error(e.message)
+    process.exit(1)
+  })

--- a/test/server.js
+++ b/test/server.js
@@ -1,14 +1,20 @@
-const http = require('http');
+const argv = require('minimist')(process.argv.slice(2), {
+  alias: {
+    port: 'p'
+  }
+})
+const http = require('http')
 const server = http.createServer((req, res) => {
   console.log(req.method)
   if (req.method === 'GET') {
     res.end('All good\n\n')
   } else {
-    res.end();
+    res.end()
   }
-});
+})
+const port = argv.port || 9000
 setTimeout(() => {
-  server.listen(9000)
-  console.log('listening at port 9000')
+  server.listen(port)
+  console.log('listening at port %d', port)
 }, 5000)
 console.log('sleeping for 5 seconds before starting')


### PR DESCRIPTION
- closes #165 

Allows to pass in addition to NPM script names any commands. For example

```
start-test 'http-server -c-1 --silent' 8000 'npm run test -- --verbose'
```