### PR TITLE
Add optional timeout environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ To see disable HTTPS checks for `wait-on`, run with environment variable `START_
 
 ### Timeout
 
-This utility will wait for maximum of 5 minutes while checking for the server to respond.
+This utility will wait for maximum of 5 minutes while checking for the server to respond (default). Setting an environment variable `WAIT_ON_TIMEOUT=600000` (milliseconds) sets the timeout for example to 10 minutes.
 
 ### Starting two servers
 

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,10 @@ const debug = require('debug')('start-server-and-test')
 /**
  * Used for timeout (ms)
  */
-const waitOnTimeout = process.env.WAIT_ON_TIMEOUT || 5 * 60 * 1000
+const fiveMinutes = 5 * 60 * 1000
+const waitOnTimeout = 
+  process.env.WAIT_ON_TIMEOUT ?
+  Number(process.env.WAIT_ON_TIMEOUT) : fiveMinutes
 
 const isDebug = () =>
   process.env.DEBUG && process.env.DEBUG.indexOf('start-server-and-test') !== -1

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ const debug = require('debug')('start-server-and-test')
 /**
  * Used for timeout (ms)
  */
-const fiveMinutes = 5 * 60 * 1000
+const waitOnTimeout = process.env.WAIT_ON_TIMEOUT 5 * 60 * 1000
 
 const isDebug = () =>
   process.env.DEBUG && process.env.DEBUG.indexOf('start-server-and-test') !== -1
@@ -72,7 +72,7 @@ function startAndTest ({ start, url, test }) {
       resources: Array.isArray(url) ? url : [url],
       interval: 2000,
       window: 1000,
-      timeout: fiveMinutes,
+      timeout: waitOnTimeout,
       verbose: isDebug(),
       strictSSL: !isInsecure(),
       log: isDebug()

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ const debug = require('debug')('start-server-and-test')
 /**
  * Used for timeout (ms)
  */
-const waitOnTimeout = process.env.WAIT_ON_TIMEOUT 5 * 60 * 1000
+const waitOnTimeout = process.env.WAIT_ON_TIMEOUT || 5 * 60 * 1000
 
 const isDebug = () =>
   process.env.DEBUG && process.env.DEBUG.indexOf('start-server-and-test') !== -1


### PR DESCRIPTION
Related to #148 I also needed to modify the timeout of `wait-on`. Now you can pass an environment variable `WAIT_ON_TIMEOUT={ms} start-server-and-test [...]` with a default fallback to 5 minutes when not passed. 😃 