### PR TITLE
fix: arg parsing on windows

### DIFF
--- a/__snapshots__/utils-spec.js
+++ b/__snapshots__/utils-spec.js
@@ -1,3 +1,45 @@
+exports['utils crossArguments concates arguments if wrapped by " 1'] = [
+  "start",
+  "8080",
+  "test argument --option"
+]
+
+exports['utils crossArguments concates arguments if wrapped by \' 1'] = [
+  "start",
+  "8080",
+  "test argument --option"
+]
+
+exports['utils crossArguments concates arguments if wrapped by ` 1'] = [
+  "start",
+  "8080",
+  "test argument --option"
+]
+
+exports['utils crossArguments ignores end char (") if not at the end of an argument 1'] = [
+  "start",
+  "8080",
+  "test argu\"ment --option"
+]
+
+exports['utils crossArguments ignores end char (\') if not at the end of an argument 1'] = [
+  "start",
+  "8080",
+  "test argu'ment --option"
+]
+
+exports['utils crossArguments ignores end char (`) if not at the end of an argument 1'] = [
+  "start",
+  "8080",
+  "test argu`ment --option"
+]
+
+exports['utils crossArguments ignores end chars that are != the startChar of an argument 1'] = [
+  "start",
+  "8080",
+  "test argument' --option"
+]
+
 exports['utils getArguments allows 5 arguments 1'] = {
   "args": [
     "start",

--- a/src/bin/start.js
+++ b/src/bin/start.js
@@ -2,9 +2,9 @@
 
 const debug = require('debug')('start-server-and-test')
 
-const args = process.argv.slice(2)
 const startAndTest = require('..').startAndTest
 const utils = require('../utils')
+const args = utils.crossArguments(process.argv.slice(2))
 
 debug('parsing CLI arguments: %o', args)
 const parsed = utils.getArguments(args)

--- a/src/utils-spec.js
+++ b/src/utils-spec.js
@@ -26,6 +26,39 @@ describe('utils', () => {
     })
   })
 
+  context('crossArguments', () => {
+    const crossArguments = utils.crossArguments
+    ;['"', "'", '`'].forEach(char => {
+      it(`concates arguments if wrapped by ${char}`, () => {
+        snapshot(
+          crossArguments([
+            'start',
+            '8080',
+            `${char}test`,
+            'argument',
+            `--option${char}`
+          ])
+        )
+      })
+      it(`ignores end char (${char}) if not at the end of an argument`, () => {
+        snapshot(
+          crossArguments([
+            'start',
+            '8080',
+            `${char}test`,
+            `argu${char}ment`,
+            `--option${char}`
+          ])
+        )
+      })
+    })
+    it(`ignores end chars that are != the startChar of an argument`, () => {
+      snapshot(
+        crossArguments(['start', '8080', `"test`, `argument'`, `--option"`])
+      )
+    })
+  })
+
   context('getArguments', () => {
     const getArguments = utils.getArguments
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -4,6 +4,46 @@ const { join } = require('path')
 const { existsSync } = require('fs')
 
 /**
+ * Returns new array of command line arguments
+ * where leading and trailing " and ' are indicating
+ * the beginning and end of an argument.
+ */
+const crossArguments = cliArgs => {
+  let concatModeChar = false
+  const indicationChars = ["'", '"', '`']
+  const combinedArgs = []
+  for (let i = 0; i < cliArgs.length; i++) {
+    let arg = cliArgs[i]
+    if (
+      !concatModeChar &&
+      indicationChars.some(char => cliArgs[i].startsWith(char))
+    ) {
+      arg = arg.slice(1)
+    }
+    if (concatModeChar && cliArgs[i].endsWith(concatModeChar)) {
+      arg = arg.slice(0, -1)
+    }
+
+    if (concatModeChar && combinedArgs.length) {
+      combinedArgs[combinedArgs.length - 1] += ' ' + arg
+    } else {
+      combinedArgs.push(arg)
+    }
+
+    if (
+      !concatModeChar &&
+      indicationChars.some(char => cliArgs[i].startsWith(char))
+    ) {
+      concatModeChar = cliArgs[i][0]
+    }
+    if (concatModeChar && cliArgs[i].endsWith(concatModeChar)) {
+      concatModeChar = false
+    }
+  }
+  return combinedArgs
+}
+
+/**
  * Returns parsed command line arguments.
  * If start command is NPM script name defined in the package.json
  * file in the current working directory, returns 'npm run start' command.
@@ -166,6 +206,7 @@ function printArguments ({ services, test }) {
 // placing functions into a common object
 // makes them methods for easy stubbing
 const UTILS = {
+  crossArguments,
   getArguments,
   isPackageScriptName,
   isUrlOrPort,


### PR DESCRIPTION
Windows does ignore charachters like `"` when parsing CLI arguments. The result of that is, that you can not pass options to your commands, because you can not group them as a single argument on windows machines.
This PR adds a method that manipulates the args array to concat arguments that start with something like " until another argument ends with ".

close bahmutov#239