### PR TITLE
fix: handle case when not running in a nodejs module dir

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,7 @@
 const la = require('lazy-ass')
 const is = require('check-more-types')
 const { join } = require('path')
+const { existsSync } = require('fs')
 
 /**
  * Returns parsed command line arguments.
@@ -82,6 +83,9 @@ const isPackageScriptName = command => {
   la(is.unemptyString(command), 'expected command name string', command)
 
   const packageFilename = join(process.cwd(), 'package.json')
+  if (!existsSync(packageFilename)) {
+    return false
+  }
   const packageJson = require(packageFilename)
   if (!packageJson.scripts) {
     return false


### PR DESCRIPTION
Hi there - I am trying to run "start-server-and-test" from npx to kick off a tomcat server (java) and then run some automated tests.

There is no nodejs involved, so there is no package.json, which causes the current version to die.

This change allows "start-server-and-test" to continue without requiring a package.json.