### PR TITLE
feat: add text/html to the accepted mime types

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -79,7 +79,10 @@ function waitAndRun ({ start, url, runFn }) {
       timeout: waitOnTimeout,
       verbose: isDebug(),
       strictSSL: !isInsecure(),
-      log: isDebug()
+      log: isDebug(),
+      headers: {
+        'Accept': 'text/html, application/json, text/plain, */*'
+      }
     }
     debug('wait-on options %o', options)
 


### PR DESCRIPTION
Vite dev server needs specific `text/html` to be within the `Accept` header, otherwise it won't respond with 200 OK.

By default Axios within the `wait-on` package sends this header: `'Accept': application/json, text/plain, */*'`, the below modification is just an addition

resolves #294 