### PR TITLE
FEAT: Allow interval option from environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,10 @@ To disable HTTPS checks for `wait-on`, run with environment variable `START_SERV
 
 This utility will wait for maximum of 5 minutes while checking for the server to respond (default). Setting an environment variable `WAIT_ON_TIMEOUT=600000` (milliseconds) sets the timeout for example to 10 minutes.
 
+### Interval
+
+This utility will check for a server response every two seconds (default). Setting an environment variable `WAIT_ON_INTERVAL=600000` (milliseconds) sets the interval for example to 10 minutes.
+
 ### Starting two servers
 
 Sometimes you need to start one API server and one webserver in order to test the application. Use the syntax:

--- a/package.json
+++ b/package.json
@@ -92,6 +92,8 @@
     "demo10": "node src/bin/start.js start-fail http://127.0.0.1:9000 test",
     "demo11": "node src/bin/start.js http-get://127.0.0.1:9000",
     "demo12": "node src/bin/start.js start-304 9000 test2",
+    "demo-interval": "WAIT_ON_INTERVAL=1000 node src/bin/start.js start http://127.0.0.1:9000 test2",
+    "demo-timeout": "WAIT_ON_TIMEOUT=10000 node src/bin/start.js start http://127.0.0.1:9000 test2",
     "demo-cross-env": "node src/bin/start.js start-cross-env 9000",
     "demo-commands": "node src/bin/start.js 'node test/server.js --port 8800' 8800 'node test/client --port 8800'",
     "demo-multiple": "node src/bin/start.js 'node test/server --port 6000' 6000 'node test/server --port 6010' 6010 'curl http://127.0.0.1:6000 && curl http://127.0.0.1:6010'",

--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,7 @@ const debug = require('debug')('start-server-and-test')
  * Used for timeout (ms)
  */
 const fiveMinutes = 5 * 60 * 1000
-const twoSeconds = 2_000
+const twoSeconds = 2000
 
 const waitOnTimeout = process.env.WAIT_ON_TIMEOUT
   ? Number(process.env.WAIT_ON_TIMEOUT)

--- a/src/index.js
+++ b/src/index.js
@@ -13,9 +13,15 @@ const debug = require('debug')('start-server-and-test')
  * Used for timeout (ms)
  */
 const fiveMinutes = 5 * 60 * 1000
+const twoSeconds = 2_000
+
 const waitOnTimeout = process.env.WAIT_ON_TIMEOUT
   ? Number(process.env.WAIT_ON_TIMEOUT)
   : fiveMinutes
+
+const waitOnInterval = process.env.WAIT_ON_INTERVAL
+  ? Number(process.env.WAIT_ON_INTERVAL)
+  : twoSeconds
 
 const isDebug = () =>
   process.env.DEBUG && process.env.DEBUG.indexOf('start-server-and-test') !== -1
@@ -74,7 +80,7 @@ function waitAndRun ({ start, url, runFn }) {
     debug('starting waitOn %s', url)
     const options = {
       resources: Array.isArray(url) ? url : [url],
-      interval: 2000,
+      interval: waitOnInterval,
       window: 1000,
       timeout: waitOnTimeout,
       verbose: isDebug(),

--- a/src/utils.js
+++ b/src/utils.js
@@ -199,6 +199,14 @@ function printArguments ({ services, test }) {
     )
   })
 
+  if (process.env.WAIT_ON_INTERVAL !== undefined) {
+    console.log('WAIT_ON_INTERVAL is set to', process.env.WAIT_ON_INTERVAL)
+  }
+
+  if (process.env.WAIT_ON_TIMEOUT !== undefined) {
+    console.log('WAIT_ON_TIMEOUT is set to', process.env.WAIT_ON_TIMEOUT)
+  }
+
   console.log('running tests using command "%s"', test)
   console.log('')
 }


### PR DESCRIPTION
Starting our app in NextJS dev takes a bit longer to finishing compilation. Hitting the `/` route with `wait-on` every two seconds while compiling leads to the app constantly re-compiling and rarely finishing it's build before the timeout ends.

Adding an option for interval would be great, to allow us to check our route much less frequently.

In this PR I'm adding this option as an ENV variable, sticking to the current convention for TIMEOUT