### PR TITLE
Update README.md with changed minor node version requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ## Install
 
-Requires [Node](https://nodejs.org/en/) version 8.9 or above.
+Requires [Node](https://nodejs.org/en/) version 12 or above.
 
 ```sh
 npm install --save-dev start-server-and-test


### PR DESCRIPTION
`wait-on` library depends on `mocha` which depends on node 12+