### PR TITLE
Fix interactive shell in the test process

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -44,7 +44,7 @@ function waitAndRun ({ start, url, runFn, namedArguments }) {
 
   debug('starting server with command "%s", verbose mode?', start, isDebug())
 
-  const server = execa(start, { shell: true, stdio: 'inherit' })
+  const server = execa(start, { shell: true, stdio: ['ignore', 'inherit', 'inherit'] })
   let serverStopped
 
   function stopServer () {


### PR DESCRIPTION
Fixes the issue that interactive stdin in the test process was erratic, due to that the main process's stdin was piped to both the server and the test processes.