### PR TITLE
Update default HTTP status code expectation

### DIFF
--- a/src/bin/start.js
+++ b/src/bin/start.js
@@ -19,7 +19,7 @@ if (!Array.isArray(services)) {
 }
 
 if (!namedArguments.expect) {
-  namedArguments.expect = 200
+  namedArguments.expect = -1
 }
 
 utils.printArguments({ services, test, namedArguments })

--- a/src/index.js
+++ b/src/index.js
@@ -38,7 +38,7 @@ function waitAndRun ({ start, url, runFn, namedArguments }) {
   )
   const isSuccessfulHttpCode = status =>
     (status >= 200 && status < 300) || status === 304
-  const validateStatus = namedArguments.expect
+  const validateStatus = namedArguments.expect !== -1
     ? status => status === namedArguments.expect
     : isSuccessfulHttpCode
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -244,9 +244,9 @@ function printArguments ({ services, test, namedArguments }) {
   services.forEach((service, k) => {
     console.log('%d: starting server using command "%s"', k + 1, service.start)
     console.log(
-      'and when url "%s" is responding with HTTP status code %d',
+      'and when url "%s" is responding with HTTP status code %s',
       service.url,
-      namedArguments.expect
+      namedArguments.expect === -1 ? '2xx or 304' : namedArguments.expect.toString()
     )
   })
 


### PR DESCRIPTION
This PR changes how the expect argument works. Before, it only accepted port 200 if no expect argument was given, and it would fail if the response port was different. This was a problem when the server returned valid ports like 204 or 304, which mean no content or not modified.

Now, the default behavior is to accept ports 200-299 and 304. The client will only fail if the response port is not in this list or range. This makes the client more flexible to handle different kinds of successful responses.