### PR TITLE
chore(docs): add Windows wmic information to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@
 
 ## Install
 
-Requires [Node](https://nodejs.org/en/) version 16 or above.
+- Requires [Node](https://nodejs.org/en/) version 16 or above.
+- Requires the "Windows Management Instrumentation command-line" (WMIC) utility on Windows for shut down server functionality. Refer to [How to install WMIC Feature on Demand on Windows 11](https://techcommunity.microsoft.com/blog/windows-itpro-blog/how-to-install-wmic-feature-on-demand-on-windows-11/4189530) if you are using Windows 11 24H2, since WMIC is no longer installed by default.
 
 ```sh
 npm install --save-dev start-server-and-test

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 ## Install
 
 - Requires [Node](https://nodejs.org/en/) version 16 or above.
-- Requires the "Windows Management Instrumentation command-line" (WMIC) utility on Windows for shut down server functionality. Refer to [How to install WMIC Feature on Demand on Windows 11](https://techcommunity.microsoft.com/blog/windows-itpro-blog/how-to-install-wmic-feature-on-demand-on-windows-11/4189530) if you are using Windows 11 24H2, since WMIC is no longer installed by default.
+- Requires the "Windows Management Instrumentation command-line" (WMIC) utility on Windows for shut down server functionality. Refer to [How to install WMIC Feature on Demand on Windows 11](https://techcommunity.microsoft.com/blog/windows-itpro-blog/how-to-install-wmic-feature-on-demand-on-windows-11/4189530) if you are using Windows 11 24H2 or Windows Server 2025, since WMIC is no longer installed by default.
 
 ```sh
 npm install --save-dev start-server-and-test


### PR DESCRIPTION
- Relates to #384

## Issue

`start-server-and-test` uses the unmaintained npm package [ps-tree@1.2.0](https://www.npmjs.com/package/ps-tree), last published 6 years ago, with cross-platform support, to implement the shut down server functionality.

As shown in the [ps-tree > README > Windows](https://github.com/indexzero/ps-tree/blob/master/README.md#windows) section, `ps-tree` makes use of the `wmic` utility on Windows. This is the "Windows Management Instrumentation command-line" utility executable, also referred to as `WMIC` (upper case).

WMIC has however been deprecated by Microsoft since Aug 2016 and is removed by default in Windows 11 24H2 and Windows Server 2025.

There is currently no higher version of `ps-tree` available which removes the dependency on WMIC. There are two associated open PRs https://github.com/indexzero/ps-tree/pull/59 and https://github.com/indexzero/ps-tree/pull/62 which have not received any maintainer feedback.

## Change

Add information into the [README > Install](https://github.com/bahmutov/start-server-and-test/blob/master/README.md#install) section for Windows 11 24H2 and Windows Server 2025.

## References

- [Features Removed or Deprecated in Windows Server 2012](https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2012-r2-and-2012/hh831568(v=ws.11)) Aug 30, 2016
  - [WMI providers](https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2012-r2-and-2012/hh831568(v=ws.11)#wmi-providers)
  >
  > The WMI command-line tool (Wmic) is deprecated. Use PowerShell cmdlets instead.
- [Deprecated features for Windows client](https://learn.microsoft.com/en-us/windows/whats-new/deprecated-features) Nov 14, 2024
  >
  > Windows Management Instrumentation command-line (WMIC) utility.
  >
  > The WMIC utility is deprecated in Windows 10, version 21H1 and the 21H1 General Availability Channel release of Windows Server. This utility is superseded by Windows PowerShell for WMI. Note: This deprecation applies to only the command-line management utility. WMI itself isn't affected.
  >
  > [Update - January 2024]: Currently, WMIC is a Feature on Demand (FoD) that's preinstalled by default in Windows 11, versions 23H2 and 22H2. In the next release of Windows, the WMIC FoD will be disabled by default.

- [WMI command line (WMIC) utility deprecation: Next steps](https://techcommunity.microsoft.com/blog/windows-itpro-blog/wmi-command-line-wmic-utility-deprecation-next-steps/4039242)

- [How to install WMIC Feature on Demand on Windows 11](https://techcommunity.microsoft.com/blog/windows-itpro-blog/how-to-install-wmic-feature-on-demand-on-windows-11/4189530)