### PR TITLE
fix: formatting the message in the constructor of Error object

### DIFF
--- a/src/bin/start.js
+++ b/src/bin/start.js
@@ -15,7 +15,7 @@ debug('parsed args: %o', parsed)
 
 const { services, test } = parsed
 if (!Array.isArray(services)) {
-  throw new Error(`Could not parse arguments %o, got %o`, args, parsed)
+  throw new Error(`Could not parse arguments ${JSON.stringify(args)}, got ${JSON.stringify(parsed)}`)
 }
 
 if (!namedArguments.expect) {


### PR DESCRIPTION
In bin/start.js line 18 a new Error object is created with some kind of printf-style string formatter, but AFAIK the constructor of Error does not support this kind of formatting.

Changed the formatting using Template literals.