### PR TITLE
chore(renovate): restrict lazy-ass to <2 for compatibility

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,6 +17,10 @@
     {
       "matchPackageNames": ["execa"],
       "allowedVersions": "<6"
+    },
+    {
+      "matchPackageNames": ["lazy-ass"],
+      "allowedVersions": "<2"
     }
   ]
 }


### PR DESCRIPTION
## Situation

The repo is configured with [lazy-ass@1.6.0](https://github.com/bahmutov/lazy-ass/releases/tag/v1.6.0) released 2017-03-15. This is the highest `lazy-ass` v1.x release.

The next release is [lazy-ass@2.0.2](https://github.com/bahmutov/lazy-ass/releases/tag/v2.0.2) and the latest release is [lazy-ass@2.0.3](https://github.com/bahmutov/lazy-ass/releases/tag/v2.0.3), released 2021-10-18.

lazy-ass `v1.x` to `v2.x` is a breaking change, requiring code changes to `start-server-and-test`.

## Change

Add rule to [renovate.json](https://github.com/bahmutov/start-server-and-test/blob/master/renovate.json) to prevent Renovate from attempting an update from `lazy-ass@1.6.0` to `lazy-ass@2`.

## References

- [packageRules.matchPackageNames](https://docs.renovatebot.com/configuration-options/#packagerulesmatchpackagenames)
- [packageRules.allowedVersions](https://docs.renovatebot.com/configuration-options/#packagerulesallowedversions)
