### PR TITLE
fix(deps): pin arg to 5.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0-development",
       "license": "MIT",
       "dependencies": {
-        "arg": "^5.0.2",
+        "arg": "5.0.2",
         "bluebird": "3.7.2",
         "check-more-types": "2.24.0",
         "debug": "4.4.3",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "snap-shot-it": "7.9.10"
   },
   "dependencies": {
-    "arg": "^5.0.2",
+    "arg": "5.0.2",
     "bluebird": "3.7.2",
     "check-more-types": "2.24.0",
     "debug": "4.4.3",


### PR DESCRIPTION
## Situation

In the `dependencies` list of [package.json](https://github.com/bahmutov/start-server-and-test/blob/master/package.json) the npm module [arg@^5.0.2](https://github.com/vercel/arg/releases/tag/5.0.2), (current `latest`, released Jun 5, 2022) is the only dependency defined with a SemVer range.

## Change

Change from SemVer range [arg@^5.0.2](https://github.com/vercel/arg/releases/tag/5.0.2) to pinned version [arg@5.0.2](https://github.com/vercel/arg/releases/tag/5.0.2) for consistency.