### PR TITLE
chore(ci): add Node.js 26 to tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,7 @@ jobs:
           - 22
           - 24
           - 25
+          - 26
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
## Situation

The workflow [ci](https://github.com/bahmutov/start-server-and-test/blob/master/.github/workflows/ci.yml) job `tests-node-matrix` tests in Node.js 22, 24 & 25.

[Node.js 26.0.0](https://nodejs.org/en/blog/release/v26.0.0) was released on May 5, 2026.

## Change

Add Node.js 26 to the job `tests-node-matrix` in the workflow [ci](https://github.com/bahmutov/start-server-and-test/blob/master/.github/workflows/ci.yml).