### PR TITLE
fix: improve check for already exited processes on windows

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -62,7 +62,23 @@ function waitAndRun({ start, url, runFn, namedArguments }) {
       return Promise.fromNode((cb) =>
         kill(server.pid, 'SIGINT', cb),
       ).catch((err) => {
-        if (err && err.code !== 'ESRCH') {
+        const message = `${err?.message || ''}\n${err?.stdout || ''}\n${err?.stderr || ''}`
+
+        const alreadyExited =
+          // Unix system returns ESRCH when the process is already gone
+          err?.code === 'ESRCH' ||
+          // Windows: "ERROR: The process "<pid>" not found."
+          /ERROR:\s*The process\s+.+\s+not found\./i.test(message) ||
+          // Windows: "Reason: There is no running instance of the task."
+          /Reason:\s*There is no running instance of the task\./i.test(
+            message,
+          ) ||
+          // Windows: "FEHLER: Der Prozess "<pid>" wurde nicht gefunden."
+          /FEHLER:\s*Der Prozess\s+.+\s+wurde nicht gefunden\./i.test(
+            message,
+          )
+
+        if (!alreadyExited) {
           throw err
         }
         debug('process already exited')

--- a/src/start-server-and-test-spec.js
+++ b/src/start-server-and-test-spec.js
@@ -1,10 +1,30 @@
 'use strict'
 
 /* eslint-env mocha */
-const startServerAndTest = require('.')
+const { startAndTest } = require('.')
 
 describe('start-server-and-test', () => {
   it('write this test', () => {
-    console.assert(startServerAndTest, 'should export something')
+    console.assert(startAndTest, 'should export something')
+  })
+
+  // Tests the case where the server process exits on its own before stopServer() is called.
+  // On Unix tree-kill returns ESRCH; on Windows taskkill returns an error with a message indicating the process was not found.
+  // This should NOT cause startAndTest to reject.
+  it('resolves when the server exits before stopServer() is called', function () {
+    this.timeout(20000)
+
+    const port = 19877
+    return startAndTest({
+      services: [
+        {
+          start: 'node test/server-exits-early.js',
+          url: `http://127.0.0.1:${port}`,
+        },
+      ],
+      // Keep the test command running longer than the server lives (4s) so that stopServer() is called after the process has already exited.
+      test: 'node -e "setTimeout(()=>{},6000)"',
+      namedArguments: { expect: 200 },
+    })
   })
 })

--- a/test/server-exits-early.js
+++ b/test/server-exits-early.js
@@ -1,0 +1,24 @@
+'use strict'
+
+/**
+ * A server that starts listening immediately, then exits on its own after a short delay.
+ * Used by the alreadyExited E2E test: the server is gone before stopServer() is called, which should NOT cause startAndTest to reject.
+ */
+const http = require('http')
+
+const PORT = process.env.SERVER_EXITS_EARLY_PORT || 19877
+
+const server = http.createServer((_req, res) => {
+  res.end('ok')
+})
+
+server.listen(PORT, () => {
+  console.log('server-exits-early listening on port %s', PORT)
+  // Stay up for 4s so that waitOn (default interval 2s + window 1s) can resolve and remove the 'close' listener before we exit.
+  // The test command runs for 6s, so stopServer() is called ~2s after we are already gone, exercising the alreadyExited path on every platform.
+  setTimeout(() => {
+    console.log('server-exits-early shutting down intentionally')
+    server.close()
+    process.exit(0)
+  }, 4000)
+})


### PR DESCRIPTION
* On Windows, already exited processes are not (always) reported as ESRCH, therefore match the error message to check if the process already exited