### PR TITLE
chore(deps): add minimum release age for installation / updating

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=7

--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,7 @@
   "schedule": ["before 2am"],
   "updateNotScheduled": false,
   "timezone": "America/New_York",
+  "minimumReleaseAge": "7 days",
   "packageRules": [
     {
       "matchDepTypes": ["devDependencies"],


### PR DESCRIPTION
## Issue

The [renovate configuration](https://github.com/bahmutov/start-server-and-test/blob/master/renovate.json) includes `automerge` with no built-in delay. This constitutes a supply chain security risk.

## Change

Add the following settings to decrease the susceptibility to undetected issues in packages recently released. This allows time for community assessment and remediation if necessary, before package updates are committed.

### Renovate

Add the following to [renovate configuration](https://github.com/bahmutov/start-server-and-test/blob/master/renovate.json):

```json
  "minimumReleaseAge": "7 days"
```

- [Minimum Release Age](https://docs.renovatebot.com/key-concepts/minimum-release-age/)

### npm

Create `.npmrc` with the following contents:

```text
min-release-age=7
```

- [min-release-age](https://docs.npmjs.com/cli/v11/using-npm/config#min-release-age)
