### PR TITLE
chore(ci): drop Node.js 25 from tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,6 @@ jobs:
         node:
           - 22
           - 24
-          - 25
           - 26
     steps:
       - name: Checkout


### PR DESCRIPTION
## Situation

The workflow [ci](https://github.com/bahmutov/start-server-and-test/blob/master/.github/workflows/ci.yml) job `tests-node-matrix` tests in Node.js 22, 24, 25 & 26

Node.js 26.0.0 transitioned into [End-of-life](https://github.com/nodejs/release#end-of-life-releases) status on June 1, 2026 and is therefore generally unsupported.

## Change

Remove Node.js 26 from the job `tests-node-matrix` in the workflow [ci](https://github.com/bahmutov/start-server-and-test/blob/master/.github/workflows/ci.yml).