### PR TITLE
chore: specify minimumReleaseAge 7 days for renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,7 @@
   "major": {
     "automerge": false
   },
+  "minimumReleaseAge": "7 days",
   "dependencyDashboard": true,
   "schedule": ["before 2am"],
   "updateNotScheduled": false,


### PR DESCRIPTION
Should make things a little safer from supply chain attacks. Also, this would probably not happen: https://packagephobia.com/result?p=start-server-and-test%403.0.3%2Cstart-server-and-test%403.0.4