### PR TITLE
test: fix typos, wrong assertion, and placeholder test

### DIFF
--- a/__snapshots__/utils-spec.js
+++ b/__snapshots__/utils-spec.js
@@ -1,16 +1,16 @@
-exports['utils crossArguments concates arguments if wrapped by " 1'] = [
+exports['utils crossArguments concatenates arguments if wrapped by " 1'] = [
   "start",
   "8080",
   "test argument --option"
 ]
 
-exports['utils crossArguments concates arguments if wrapped by \' 1'] = [
+exports['utils crossArguments concatenates arguments if wrapped by \' 1'] = [
   "start",
   "8080",
   "test argument --option"
 ]
 
-exports['utils crossArguments concates arguments if wrapped by ` 1'] = [
+exports['utils crossArguments concatenates arguments if wrapped by ` 1'] = [
   "start",
   "8080",
   "test argument --option"

--- a/src/start-server-and-test-spec.js
+++ b/src/start-server-and-test-spec.js
@@ -4,8 +4,8 @@
 const { startAndTest } = require('.')
 
 describe('start-server-and-test', () => {
-  it('write this test', () => {
-    console.assert(startAndTest, 'should export something')
+  it('is a function', () => {
+    expect(startAndTest).to.be.a('function')
   })
 
   // Tests the case where the server process exits on its own before stopServer() is called.

--- a/src/utils-spec.js
+++ b/src/utils-spec.js
@@ -31,7 +31,7 @@ describe('utils', () => {
   context('crossArguments', () => {
     const crossArguments = utils.crossArguments
     ;['"', "'", '`'].forEach((char) => {
-      it(`concates arguments if wrapped by ${char}`, () => {
+      it(`concatenates arguments if wrapped by ${char}`, () => {
         snapshot(
           crossArguments([
             'start',
@@ -187,7 +187,7 @@ describe('utils', () => {
     })
 
     it('allows url with https-options', () => {
-      la(isUrlOrPort('https-head://foo'))
+      la(isUrlOrPort('https-options://foo'))
     })
 
     it('allows port number or string', () => {
@@ -261,10 +261,13 @@ describe('utils', () => {
     })
 
     it('returns original argument if does not know what to do', () => {
-      la(arrayEq(normalizeUrl('foo'), ['foo']), normalizeUrl('foo'))
+      la(
+        arrayEq(normalizeUrl('foo'), ['foo']),
+        'normalizeUrl("foo") should return ["foo"]',
+      )
       la(
         arrayEq(normalizeUrl(808000), [808000]),
-        normalizeUrl(808000),
+        'normalizeUrl(808000) should return [808000]',
       )
     })
 


### PR DESCRIPTION
- fix typo "concates" -> "concatenates"
- fix isUrlOrPort "https-options" test was testing https-head:// instead
- fix la() error messages were arrays, not strings
- fix console.assert placeholder -> chai assertion