### PR TITLE
fix(deps): update lazy-ass to v2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "check-more-types": "2.24.0",
         "debug": "4.4.3",
         "execa": "5.1.1",
-        "lazy-ass": "1.6.0",
+        "lazy-ass": "2.0.3",
         "tree-kill": "1.2.2",
         "wait-on": "9.0.10"
       },
@@ -53,6 +53,16 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/@bahmutov/data-driven/node_modules/lazy-ass": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/lazy-ass/-/lazy-ass-1.6.0.tgz",
+      "integrity": "sha512-cc8oEVoctTvsFZ/Oje/kGnHbpWHYBe8IAJe4C0QNc3t8uM/0Y8+erSz/7Y1ALuXTEZTMvxXwO6YbX1ey3ujiZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "> 0.8"
       }
     },
     "node_modules/@hapi/address": {
@@ -2896,9 +2906,9 @@
       }
     },
     "node_modules/lazy-ass": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/lazy-ass/-/lazy-ass-1.6.0.tgz",
-      "integrity": "sha512-cc8oEVoctTvsFZ/Oje/kGnHbpWHYBe8IAJe4C0QNc3t8uM/0Y8+erSz/7Y1ALuXTEZTMvxXwO6YbX1ey3ujiZw==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/lazy-ass/-/lazy-ass-2.0.3.tgz",
+      "integrity": "sha512-/O3/DoQmI1XAhklDvF1dAjFf/epE8u3lzOZegQfLZ8G7Ud5bTRSZiFOpukHCu6jODrCA4gtIdwUCC7htxcDACA==",
       "license": "MIT",
       "engines": {
         "node": "> 0.8"
@@ -4505,6 +4515,16 @@
         "ms": "^2.1.1"
       }
     },
+    "node_modules/snap-shot-compare/node_modules/lazy-ass": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/lazy-ass/-/lazy-ass-1.6.0.tgz",
+      "integrity": "sha512-cc8oEVoctTvsFZ/Oje/kGnHbpWHYBe8IAJe4C0QNc3t8uM/0Y8+erSz/7Y1ALuXTEZTMvxXwO6YbX1ey3ujiZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "> 0.8"
+      }
+    },
     "node_modules/snap-shot-core": {
       "version": "10.2.4",
       "resolved": "https://registry.npmjs.org/snap-shot-core/-/snap-shot-core-10.2.4.tgz",
@@ -4566,6 +4586,16 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/snap-shot-core/node_modules/lazy-ass": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/lazy-ass/-/lazy-ass-1.6.0.tgz",
+      "integrity": "sha512-cc8oEVoctTvsFZ/Oje/kGnHbpWHYBe8IAJe4C0QNc3t8uM/0Y8+erSz/7Y1ALuXTEZTMvxXwO6YbX1ey3ujiZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "> 0.8"
       }
     },
     "node_modules/snap-shot-core/node_modules/mkdirp": {
@@ -4634,6 +4664,16 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/snap-shot-it/node_modules/lazy-ass": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/lazy-ass/-/lazy-ass-1.6.0.tgz",
+      "integrity": "sha512-cc8oEVoctTvsFZ/Oje/kGnHbpWHYBe8IAJe4C0QNc3t8uM/0Y8+erSz/7Y1ALuXTEZTMvxXwO6YbX1ey3ujiZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "> 0.8"
       }
     },
     "node_modules/snap-shot-it/node_modules/ms": {

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "check-more-types": "2.24.0",
     "debug": "4.4.3",
     "execa": "5.1.1",
-    "lazy-ass": "1.6.0",
+    "lazy-ass": "2.0.3",
     "tree-kill": "1.2.2",
     "wait-on": "9.0.10"
   }

--- a/renovate.json
+++ b/renovate.json
@@ -17,10 +17,6 @@
     {
       "matchPackageNames": ["execa"],
       "allowedVersions": "<6"
-    },
-    {
-      "matchPackageNames": ["lazy-ass"],
-      "allowedVersions": "<2"
     }
   ]
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 // @ts-check
 'use strict'
 
-const la = require('lazy-ass')
+const { lazyAss: la } = require('lazy-ass')
 const is = require('check-more-types')
 const execa = require('execa')
 const waitOn = require('wait-on')

--- a/src/utils-spec.js
+++ b/src/utils-spec.js
@@ -1,7 +1,7 @@
 'use strict'
 
 /* eslint-env mocha */
-const la = require('lazy-ass')
+const { lazyAss: la } = require('lazy-ass')
 const snapshot = require('snap-shot-it')
 const debug = require('debug')('test')
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,4 @@
-const la = require('lazy-ass')
+const { lazyAss: la } = require('lazy-ass')
 const is = require('check-more-types')
 const { join } = require('path')
 const { existsSync } = require('fs')


### PR DESCRIPTION
The only breaking change AFAICT is the named imports.