### PR TITLE
docs: README cleanup and tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 > Starts server, waits for URL, then runs test command; when the tests end, shuts down server
 
-[![NPM][npm-icon] ][npm-url]
+[![npm][npm-icon]][npm-url]
 
-[![Build status][ci-image] ][ci-url]
-[![semantic-release][semantic-image] ][semantic-url]
+[![Build status][ci-image]][ci-url]
+[![semantic-release][semantic-image]][semantic-url]
 [![renovate-bot badge][renovate-badge]][renovate-bot]
 
 ## Install
@@ -22,24 +22,24 @@ npm install --save-dev start-server-and-test
 
 If you are using just the port number, and the resolved URL `localhost:xxxx` no longer works, use the explicit `http://localhost:xxxx` instead
 
-```
+```sh
 # v1
-$ npx start-test 3000
+npx start-test 3000
 # v2
-$ npx start-test http://localhost:3000
+npx start-test http://localhost:3000
 ```
 
 ## Use
 
-This command is meant to be used with NPM script commands. If you have a "start server", and "test" script names for example, you can start the server, wait for a url to respond, then run tests. When the test process exits, the server is shut down.
+This command is meant to be used with npm script commands. If you have a "start server", and "test" script names for example, you can start the server, wait for a URL to respond, then run tests. When the test process exits, the server is shut down.
 
 ```json
 {
-    "scripts": {
-        "start-server": "npm start",
-        "test": "mocha e2e-spec.js",
-        "ci": "start-server-and-test start-server http://localhost:8080 test"
-    }
+  "scripts": {
+    "start-server": "npm start",
+    "test": "mocha e2e-spec.js",
+    "ci": "start-server-and-test start-server http://localhost:8080 test"
+  }
 }
 ```
 
@@ -47,11 +47,11 @@ To execute all tests simply run `npm run ci`.
 
 ### Commands
 
-In addition to using NPM script names, you can pass entire commands (surround them with quotes so it is still a single string) that will be executed "as is". For example, to start globally installed `http-server` before running and recording [Cypress.io](https://www.cypress.io) tests you can use
+In addition to using npm script names, you can pass entire commands (surround them with quotes so it is still a single string) that will be executed "as is". For example, to start globally installed `http-server` before running and recording [Cypress.io](https://www.cypress.io) tests you can use:
 
-```shell
+```sh
 # run http-server, then when port 8000 responds run Cypress tests
-start-server-and-test 'http-server -c-1 --silent' 8000 './node_modules/.bin/cypress run --record'
+start-server-and-test "http-server -c-1 --silent" 8000 "./node_modules/.bin/cypress run --record"
 ```
 
 Because `npm` scripts execute with `./node_modules/.bin` in the `$PATH`, you can mix global and locally installed tools when using commands inside `package.json` file. For example, if you want to run a single spec file:
@@ -59,18 +59,18 @@ Because `npm` scripts execute with `./node_modules/.bin` in the `$PATH`, you can
 ```json
 {
   "scripts": {
-    "ci": "start-server-and-test 'http-server -c-1 --silent' 8080 'cypress run --spec cypress/integration/location.spec.js'"
+    "ci": "start-server-and-test \"http-server -c-1 --silent\" 8080 \"cypress run --spec cypress/integration/location.spec.js\""
   }
 }
 ```
 
-Or you can move `http-server` part into its own `start` script, which is used by default and have the equivalent JSON
+Or you can move the `http-server` part into its own `start` script, which is used by default and have the equivalent JSON
 
 ```json
 {
   "scripts": {
     "start": "http-server -c-1 --silent",
-    "ci": "start-server-and-test 8080 'cypress run --spec cypress/integration/location.spec.js'"
+    "ci": "start-server-and-test 8080 \"cypress run --spec cypress/integration/location.spec.js\""
   }
 }
 ```
@@ -80,7 +80,7 @@ Here is another example that uses Mocha
 ```json
 {
   "scripts": {
-    "ci": "start-server-and-test 'http-server -c-1 --silent' 8080 'mocha e2e-spec.js'"
+    "ci": "start-server-and-test \"http-server -c-1 --silent\" 8080 \"mocha e2e-spec.js\""
   }
 }
 ```
@@ -91,7 +91,7 @@ You can use either `start-server-and-test`, `server-test` or `start-test` comman
 
 You can use `:` in front of port number like `server-test :8080`, so all these are equivalent
 
-```
+```sh
 start-server-and-test start http://127.0.0.1:8080 test
 server-test start http://127.0.0.1:8080 test
 server-test http://127.0.0.1:8080 test
@@ -101,7 +101,7 @@ start-test 8080 test
 start-test 8080
 ```
 
-**Tip:** I highly recommend you specify the full url instead of the port, see the `localhost vs 0.0.0.0 vs 127.0.0.1` section later in this README.
+**Tip:** I highly recommend you specify the full URL instead of the port, see the `localhost vs 0.0.0.0 vs 127.0.0.1` section later in this README.
 
 ### Options
 
@@ -109,35 +109,35 @@ If you use convention and name your scripts "start" and "test" you can simply pr
 
 ```json
 {
-    "scripts": {
-        "start": "npm start",
-        "test": "mocha e2e-spec.js",
-        "ci": "start-server-and-test http://localhost:8080"
-    }
+  "scripts": {
+    "start": "npm start",
+    "test": "mocha e2e-spec.js",
+    "ci": "start-server-and-test http://localhost:8080"
+  }
 }
 ```
 
-You can also shorten local url to just port, the code below is equivalent to checking `http://127.0.0.1:8080`.
+You can also shorten local URL to just port, the code below is equivalent to checking `http://127.0.0.1:8080`.
 
 ```json
 {
-    "scripts": {
-        "start": "npm start",
-        "test": "mocha e2e-spec.js",
-        "ci": "server-test 8080"
-    }
+  "scripts": {
+    "start": "npm start",
+    "test": "mocha e2e-spec.js",
+    "ci": "server-test 8080"
+  }
 }
 ```
 
-You can provide first start command, port (or url) and implicit `test` command
+You can provide first start command, port (or URL) and implicit `test` command
 
 ```json
 {
-    "scripts": {
-        "start-it": "npm start",
-        "test": "mocha e2e-spec.js",
-        "ci": "server-test start-it 8080"
-    }
+  "scripts": {
+    "start-it": "npm start",
+    "test": "mocha e2e-spec.js",
+    "ci": "server-test start-it 8080"
+  }
 }
 ```
 
@@ -145,11 +145,11 @@ You can provide port number and custom test command, in that case `npm start` is
 
 ```json
 {
-    "scripts": {
-        "start": "npm start",
-        "test-it": "mocha e2e-spec.js",
-        "ci": "server-test :9000 test-it"
-    }
+  "scripts": {
+    "start": "npm start",
+    "test-it": "mocha e2e-spec.js",
+    "ci": "server-test :9000 test-it"
+  }
 }
 ```
 
@@ -165,7 +165,7 @@ You can provide multiple resources to wait on, separated by a pipe `|`. _(be sur
 }
 ```
 
-or for multiple ports simply: `server-test '8000|9000' test`.
+or for multiple ports simply: `server-test "8000|9000" test`.
 
 If you want to start the server, wait for it to respond, and then run multiple test commands (and stop the server after they finish), you should be able to use `&&` to separate the test commands:
 
@@ -175,22 +175,22 @@ If you want to start the server, wait for it to respond, and then run multiple t
     "start": "npm start",
     "test:unit": "mocha test.js",
     "test:e2e": "mocha e2e.js",
-    "ci": "start-test 9000 'npm run test:unit && npm run test:e2e'"
+    "ci": "start-test 9000 \"npm run test:unit && npm run test:e2e\""
   }
 }
 ```
 
-The above script `ci` after the `127.0.0.1:9000` responds executes the `npm run test:unit` command. Then when it finishes it runs `npm run test:e2e`. If the first or second command fails, the `ci` script fails. Of course, your mileage on Windows might vary.
+The above script `ci` after the `127.0.0.1:9000` responds executes the `npm run test:unit` command. Then when it finishes it runs `npm run test:e2e`. If the first or second command fails, the `ci` script fails.
 
 #### expected
 
 The server might respond, but require authorization, returning an error HTTP code by default. You can still know that the server is responding by using `--expect` argument (or its alias `--expected`):
 
-```
-$ start-test --expect 403 start :9000 test:e2e
+```sh
+start-test --expect 403 start :9000 test:e2e
 ```
 
-See `demo-expect-403` NPM script.
+See `demo-expect-403` npm script.
 
 Default expected value is 200.
 
@@ -198,15 +198,15 @@ Default expected value is 200.
 
 You can have requests to the resolved URL be passed through a proxy server. To do this, specify both the `--proxy-host` and `--proxy-port` arguments. For example, specifying these as `localhost` and `8000` will pass requests through the proxy server at `localhost:8000`.
 
-```
-$ start-test --proxy-host localhost --proxy-port 8000 start :9000 test:e2e
+```sh
+start-test --proxy-host localhost --proxy-port 8000 start :9000 test:e2e
 ```
 
 Authentication is also supported, as well as custom protocol for the proxy (e.g. `socks5` or `https`), through the `--proxy-user`, `--proxy-password`, and `--proxy-protocol` options.
 
 ## `npx` and `yarn`
 
-If you have [npx](https://www.npmjs.com/package/npx) available, you can execute locally installed tools from the shell. For example, if the `package.json` has the following local tools:
+With [npx](https://docs.npmjs.com/cli/v11/commands/npx), you can execute locally installed tools from the shell. For example, if `package.json` has the following devDependencies:
 
 ```json
 {
@@ -220,8 +220,8 @@ If you have [npx](https://www.npmjs.com/package/npx) available, you can execute 
 
 Then you can execute tests simply:
 
-```text
-$ npx start-test 'http-server -c-1 .' 8080 'cypress run'
+```console
+$ npx start-test "http-server -c-1 ." 8080 "cypress run"
 starting server using command "http-server -c-1 ."
 and when url "http://127.0.0.1:8080" is responding
 running tests using command "cypress run"
@@ -229,12 +229,12 @@ Starting up http-server, serving .
 ...
 ```
 
-Similarly, you can use [yarn](https://yarnpkg.com/en/) to call locally installed tools
+Similarly, you can use [yarn](https://classic.yarnpkg.com/en/) to call locally installed tools
 
-```text
-$ yarn start-test 'http-server -c-1 .' 8080 'cypress run'
+```console
+$ yarn start-test "http-server -c-1 ." 8080 "cypress run"
 yarn run v1.13.0
-$ /private/tmp/test-t/node_modules/.bin/start-test 'http-server -c-1 .' 8080 'cypress run'
+$ /private/tmp/test-t/node_modules/.bin/start-test "http-server -c-1 ." 8080 "cypress run"
 starting server using command "http-server -c-1 ."
 and when url "http://127.0.0.1:8080" is responding
 running tests using command "cypress run"
@@ -246,7 +246,7 @@ Starting up http-server, serving .
 
 The latest versions of Node and some web servers listen on host `0.0.0.0` which _no longer means localhost_. Thus if you specify _just the port number_, like `:3000`, this package will try `http://127.0.0.1:3000` to ping the server. A good practice is to specify the full URL you would like to ping.
 
-```
+```sh
 # same as "http://127.0.0.1:3000"
 start-server start 3000 test
 # better
@@ -260,7 +260,7 @@ start-server start http://localhost:3000 test
 
 If you specify just `localhost` or `127.0.0.1` or `0.0.0.0`, it automatically pings `http://...` URL.
 
-```
+```sh
 start-test localhost:3000
 # is the same as
 start-test http://localhost:3000
@@ -271,10 +271,12 @@ start-test http://localhost:3000
 By default, npm is used to run scripts, however you can specify that yarn is used as follows:
 
 ```json
-"scripts": {
+{
+  "scripts": {
     "start-server": "yarn start",
     "test": "mocha e2e-spec.js",
-    "ci": "start-server-and-test 'yarn start-server' http://localhost:8080 'yarn test'"
+    "ci": "start-server-and-test \"yarn start-server\" http://localhost:8080 \"yarn test\""
+  }
 }
 ```
 
@@ -282,23 +284,22 @@ By default, npm is used to run scripts, however you can specify that yarn is use
 
 Also applies to **Vite** users!
 
-If you are using [webpack-dev-server](https://www.npmjs.com/package/webpack-dev-server) (directly or via `angular/cli` or other boilerplates) then the server does not respond to HEAD requests from `start-server-and-test`. You can check if the server responds to the HEAD requests by starting the server and pinging it from another terminal using `curl`
+If you are using [webpack-dev-server](https://www.npmjs.com/package/webpack-dev-server) (directly or via `angular/cli` or other boilerplates) then the server does not respond to HEAD requests from `start-server-and-test`. You can check if the server responds to the HEAD requests by starting the server and pinging it from another terminal using `curl`:
 
-```
+```sh
 # from the first terminal start the server
-$ npm start
+npm start
 # from the second terminal call the server with HEAD request
-$ curl --head http://localhost:3000
+curl --head http://localhost:3000
 ```
 
 If the server responds with 404, then it does not handle the HEAD requests. You have two solutions:
 
 ### Use HTTP GET requests
 
-You can force the `start-server-and-test` to ping the server using GET requests using the `http-get://` prefix:
+You can force `start-server-and-test` to ping the server using `GET` requests by adding the `http-get://` prefix:
 
-
-```
+```sh
 start-server-and-test http-get://localhost:8080
 ```
 
@@ -306,7 +307,7 @@ start-server-and-test http-get://localhost:8080
 
 As an alternative to using GET method to request the root page, you can try pinging a specific resource, see the discussion in the [issue #4](https://github.com/bahmutov/start-server-and-test/issues/4).
 
-```
+```sh
 # maybe the server responds to HEAD requests to the HTML page
 start-server-and-test http://localhost:3000/index.html
 # or maybe the server responds to HEAD requests to JS resource
@@ -323,7 +324,7 @@ Under the hood this module uses [wait-on](https://github.com/jeffbski/wait-on) t
 
 To see diagnostic messages, run with environment variable `DEBUG=start-server-and-test`
 
-```
+```console
 $ DEBUG=start-server-and-test npm run test
   start-server-and-test parsing CLI arguments: [ 'dev', '3000', 'subtask' ] +0ms
   start-server-and-test parsed args: { services: [ { start: 'npm run dev', url: [Array] } ], test: 'npm run subtask' }
@@ -348,7 +349,7 @@ This utility will check for a server response every two seconds (default). Setti
 
 Sometimes you need to start one API server and one webserver in order to test the application. Use the syntax:
 
-```
+```sh
 start-test <first command> <first resource> <second command> <second resource> <test command>
 ```
 
@@ -365,7 +366,7 @@ For example if API runs at port 3000 and server runs at port 8080:
 }
 ```
 
-In the above example you would run `npm run test:all` to start the API first, then when it responds, start the server, and when the server is responding, it would run the tests. After the tests finish, it will shut down both servers. See the repo [start-two-servers-example](https://github.com/bahmutov/start-two-servers-example) for full example
+In the above example you would run `npm run test:all` to start the API first, then when it responds, start the server, and when the server is responding, it would run the tests. After the tests finish, it will shut down both servers. See the repo [start-two-servers-example](https://github.com/bahmutov/start-two-servers-example) for full example.
 
 ## Note for Apollo Server users
 
@@ -374,14 +375,14 @@ When passing a simple GET request to Apollo Server it will respond with a 405 er
 ```json
 {
   "scripts": {
-    "ci": "start-server-and-test start 'http-get://localhost:4000/graphql?query={ __schema { queryType { name } } }' test"
+    "ci": "start-server-and-test start \"http-get://localhost:4000/graphql?query={ __schema { queryType { name } } }\" test"
   }
 }
 ```
 
 ### Small print
 
-Author: Gleb Bahmutov &lt;gleb.bahmutov@gmail.com&gt; &copy; 2017
+Author: Gleb Bahmutov \<gleb.bahmutov@gmail.com\> © 2017
 
 * [@bahmutov](https://twitter.com/bahmutov)
 * [glebbahmutov.com](https://glebbahmutov.com)
@@ -390,17 +391,17 @@ Author: Gleb Bahmutov &lt;gleb.bahmutov@gmail.com&gt; &copy; 2017
 License: MIT - do anything with the code, but don't blame me if it does not work.
 
 Support: if you find any problems with this module, email / tweet /
-[open issue](https://github.com/bahmutov/start-server-and-test/issues) on Github
+[open issue](https://github.com/bahmutov/start-server-and-test/issues) on GitHub
 
 ## MIT License
 
 See [LICENSE](./LICENSE)
 
 [npm-icon]: https://nodei.co/npm/start-server-and-test.svg?downloads=true
-[npm-url]: https://npmjs.org/package/start-server-and-test
+[npm-url]: https://www.npmjs.org/package/start-server-and-test
 [ci-image]: https://github.com/bahmutov/start-server-and-test/actions/workflows/ci.yml/badge.svg
 [ci-url]: https://github.com/bahmutov/start-server-and-test/actions/workflows/ci.yml
 [semantic-image]: https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg
 [semantic-url]: https://github.com/semantic-release/semantic-release
 [renovate-badge]: https://img.shields.io/badge/renovate-enabled-brightgreen.svg
-[renovate-bot]: https://renovatebot.com/
+[renovate-bot]: https://www.mend.io/renovate/

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ start-test 8080 test
 start-test 8080
 ```
 
-**Tip:** I highly recommend you specify the full URL instead of the port, see the `localhost vs 0.0.0.0 vs 127.0.0.1` section later in this README.
+**Tip:** Specify the full URL instead of the port, see the `localhost vs 0.0.0.0 vs 127.0.0.1` section later in this README.
 
 ### Options
 

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ Starting up http-server, serving .
 ...
 ```
 
-Similarly, you can use [yarn](https://classic.yarnpkg.com/en/) to call locally installed tools
+Similarly, you can use [yarn](https://yarnpkg.com/) to call locally installed tools
 
 ```console
 $ yarn start-test "http-server -c-1 ." 8080 "cypress run"


### PR DESCRIPTION
* fix badge spacing
* lowercase "NPM" to "npm"
* capitalize "url" to "URL"
* add missing colons before code blocks
* add code blocks language
* make npm scripts use escaped double quotes
* fix indentation
* minor wording tweaks
* update npx, yarn, and renovate-bot links
* unescape HTML entities in author line

Non-whitespace diff: https://github.com/bahmutov/start-server-and-test/pull/478/changes?w=1