### PR TITLE
fix: read --proxy-password to match the documented flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ You can have requests to the resolved URL be passed through a proxy server. To d
 $ start-test --proxy-host localhost --proxy-port 8000 start :9000 test:e2e
 ```
 
-Authentication is also supported, as well as custom protocol for the proxy (e.g. `socks5` or `https`), through the `--proxy-user`, `--proxy-password`, and `--proxy-protocol` options.
+Authentication is also supported, as well as custom protocol for the proxy (e.g. `socks5` or `https`), through the `--proxy-user`, `--proxy-password`, and `--proxy-protocol` options. For backwards compatibility, `--proxy-pass` is accepted as an alias for `--proxy-password`.
 
 ## `npx` and `yarn`
 

--- a/src/utils-spec.js
+++ b/src/utils-spec.js
@@ -67,6 +67,27 @@ describe('utils', () => {
     })
   })
 
+  context('getNamedArguments', () => {
+    const getNamedArguments = utils.getNamedArguments
+
+    it('reads the proxy password from --proxy-password', () => {
+      const named = getNamedArguments([
+        '--proxy-host',
+        'h',
+        '--proxy-port',
+        '1',
+        '--proxy-user',
+        'u',
+        '--proxy-password',
+        'p',
+      ])
+      la(named.proxyHost === 'h', 'proxyHost', named)
+      la(named.proxyPort === 1, 'proxyPort', named)
+      la(named.proxyUser === 'u', 'proxyUser', named)
+      la(named.proxyPassword === 'p', 'proxyPassword', named)
+    })
+  })
+
   context('getArguments', () => {
     const getArguments = utils.getArguments
 

--- a/src/utils-spec.js
+++ b/src/utils-spec.js
@@ -86,6 +86,23 @@ describe('utils', () => {
       la(named.proxyUser === 'u', 'proxyUser', named)
       la(named.proxyPassword === 'p', 'proxyPassword', named)
     })
+
+    it('reads the proxy password from --proxy-pass alias', () => {
+      const named = getNamedArguments([
+        '--proxy-host',
+        'h',
+        '--proxy-port',
+        '1',
+        '--proxy-user',
+        'u',
+        '--proxy-pass',
+        'p',
+      ])
+      la(named.proxyHost === 'h', 'proxyHost', named)
+      la(named.proxyPort === 1, 'proxyPort', named)
+      la(named.proxyUser === 'u', 'proxyUser', named)
+      la(named.proxyPassword === 'p', 'proxyPassword', named)
+    })
   })
 
   context('getArguments', () => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -12,7 +12,7 @@ const namedArguments = {
   '--proxy-protocol': String,
   '--proxy-port': Number,
   '--proxy-user': String,
-  '--proxy-pass': String,
+  '--proxy-password': String,
 }
 
 /**

--- a/src/utils.js
+++ b/src/utils.js
@@ -13,6 +13,7 @@ const namedArguments = {
   '--proxy-port': Number,
   '--proxy-user': String,
   '--proxy-password': String,
+  '--proxy-pass': '--proxy-password',
 }
 
 /**


### PR DESCRIPTION
@MikeMcC399 this looks like it was broken from the beginning.