### PR TITLE
fix: register --expected as an alias of --expect

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,9 @@ jobs:
       - name: Run demo expect 403 code 📊
         run: npm run demo-expect-403
 
+      - name: Run demo expected 403 code 📊
+        run: npm run demo-expected-403
+
   tests-node-matrix:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "demo11": "node src/bin/start.js http-get://127.0.0.1:9000",
     "demo12": "node src/bin/start.js start-304 9000 test2",
     "demo-expect-403": "node src/bin/start.js --expect 403 start-403 9000 \"echo Waited\"",
+    "demo-expected-403": "node src/bin/start.js --expected 403 start-403 9000 \"echo Waited\"",
     "demo-interval": "cross-env WAIT_ON_INTERVAL=1000 node src/bin/start.js start http://127.0.0.1:9000 test2",
     "demo-timeout": "cross-env WAIT_ON_TIMEOUT=10000 node src/bin/start.js start http://127.0.0.1:9000 test2",
     "demo-cross-env": "node src/bin/start.js start-cross-env 9000",

--- a/src/utils-spec.js
+++ b/src/utils-spec.js
@@ -70,6 +70,32 @@ describe('utils', () => {
   context('getNamedArguments', () => {
     const getNamedArguments = utils.getNamedArguments
 
+    it('reads --expect', () => {
+      la(getNamedArguments(['--expect', '403']).expect === 403)
+    })
+
+    it('reads --expected as an alias of --expect', () => {
+      la(getNamedArguments(['--expected', '403']).expect === 403)
+    })
+
+    it('does not leak named arguments into the positional list', () => {
+      const cli = ['--expected', '403', 'start', ':9000', 'test']
+      la(
+        arrayEq(utils.crossArguments(cli), [
+          'start',
+          ':9000',
+          'test',
+        ]),
+        'named flag and its value should be stripped from positionals',
+      )
+      const parsed = utils.getArguments(utils.crossArguments(cli))
+      la(parsed.services.length === 1, 'single service', parsed)
+    })
+  })
+
+  context('getNamedArguments', () => {
+    const getNamedArguments = utils.getNamedArguments
+
     it('reads the proxy password from --proxy-password', () => {
       const named = getNamedArguments([
         '--proxy-host',

--- a/src/utils.js
+++ b/src/utils.js
@@ -7,6 +7,7 @@ const debug = require('debug')('start-server-and-test')
 
 const namedArguments = {
   '--expect': Number,
+  '--expected': '--expect',
 
   '--proxy-host': String,
   '--proxy-protocol': String,
@@ -77,8 +78,6 @@ const getNamedArguments = (cliArgs) => {
     proxyPassword: args['--proxy-password'],
     proxyPort: args['--proxy-port'],
     proxyProtocol: args['--proxy-protocol'],
-    // aliases
-    '--expected': '--expect',
   }
 }
 


### PR DESCRIPTION
Not sure if we want the demos for expect and expected anymore, I feel like the demos are too many maybe...