### PR TITLE
chore(deps): replace minimist with node:util parseArgs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,6 @@
         "cross-env": "^10.1.0",
         "husky": "9.1.7",
         "json-server": "^0.17.4",
-        "minimist": "1.2.8",
         "mocha": "^11.7.6",
         "prettier": "^3.8.1",
         "sinon": "22.0.0",
@@ -255,13 +254,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.5.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
-      "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
+      "version": "25.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.18.0"
+        "undici-types": ">=7.24.0 <7.24.7"
       }
     },
     "node_modules/accepts": {
@@ -3302,9 +3301,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -93,7 +93,6 @@
     "cross-env": "^10.1.0",
     "husky": "9.1.7",
     "json-server": "^0.17.4",
-    "minimist": "1.2.8",
     "mocha": "^11.7.6",
     "prettier": "^3.8.1",
     "sinon": "22.0.0",

--- a/test/client.js
+++ b/test/client.js
@@ -1,10 +1,15 @@
 // little test client to ping server at a given port
-const argv = require('minimist')(process.argv.slice(2), {
-  alias: {
-    port: 'p',
+const { parseArgs } = require('node:util')
+
+const { values } = parseArgs({
+  options: {
+    port: {
+      type: 'string',
+      short: 'p',
+    },
   },
 })
-const port = argv.port || 9000
+const port = Number(values.port) || 9000
 const url = `http://localhost:${port}`
 
 fetch(url, { signal: AbortSignal.timeout(10_000) })

--- a/test/server-304.js
+++ b/test/server-304.js
@@ -1,7 +1,12 @@
-const argv = require('minimist')(process.argv.slice(2), {
-  alias: {
-    port: 'p'
-  }
+const { parseArgs } = require('node:util')
+
+const { values } = parseArgs({
+  options: {
+    port: {
+      type: 'string',
+      short: 'p',
+    },
+  },
 })
 const http = require('http')
 const server = http.createServer((req, res) => {
@@ -12,7 +17,7 @@ const server = http.createServer((req, res) => {
     res.end()
   }
 })
-const port = argv.port || 9000
+const port = Number(values.port) || 9000
 setTimeout(() => {
   server.listen(port)
   console.log('listening at port %d', port)

--- a/test/server-403.js
+++ b/test/server-403.js
@@ -1,7 +1,12 @@
-const argv = require('minimist')(process.argv.slice(2), {
-  alias: {
-    port: 'p'
-  }
+const { parseArgs } = require('node:util')
+
+const { values } = parseArgs({
+  options: {
+    port: {
+      type: 'string',
+      short: 'p',
+    },
+  },
 })
 const http = require('http')
 const server = http.createServer((req, res) => {
@@ -12,7 +17,7 @@ const server = http.createServer((req, res) => {
     res.end()
   }
 })
-const port = argv.port || 9000
+const port = Number(values.port) || 9000
 setTimeout(() => {
   server.listen(port)
   console.log('listening at port %d, responding with 403', port)

--- a/test/server-as-child.js
+++ b/test/server-as-child.js
@@ -3,7 +3,7 @@ const childProcess = require('child_process');
 console.log('Starting server as child process');
 const result = childProcess.spawnSync(
   'node',
-  [].concat(require.resolve('./server')).concat(process.argv),
+  [].concat(require.resolve('./server')).concat(process.argv.slice(2)),
   { stdio: 'inherit' }
 );
 console.log('Done');

--- a/test/server.js
+++ b/test/server.js
@@ -1,7 +1,12 @@
-const argv = require('minimist')(process.argv.slice(2), {
-  alias: {
-    port: 'p'
-  }
+const { parseArgs } = require('node:util')
+
+const { values } = parseArgs({
+  options: {
+    port: {
+      type: 'string',
+      short: 'p',
+    },
+  },
 })
 const http = require('http')
 const server = http.createServer((req, res) => {
@@ -12,7 +17,7 @@ const server = http.createServer((req, res) => {
     res.end()
   }
 })
-const port = argv.port || 9000
+const port = Number(values.port) || 9000
 setTimeout(() => {
   server.listen(port)
   console.log('listening at port %d', port)


### PR DESCRIPTION
Note that this only saves us the direct dependency; minimist is still a dependency wait-on right now.