### PR TITLE
refactor: simplify env var reads in index.js

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -14,17 +14,13 @@ const debug = require('debug')('start-server-and-test')
 const fiveMinutes = 5 * 60 * 1000
 const twoSeconds = 2000
 
-const waitOnTimeout = process.env.WAIT_ON_TIMEOUT
-  ? Number(process.env.WAIT_ON_TIMEOUT)
-  : fiveMinutes
-
-const waitOnInterval = process.env.WAIT_ON_INTERVAL
-  ? Number(process.env.WAIT_ON_INTERVAL)
-  : twoSeconds
+const waitOnTimeout =
+  Number(process.env.WAIT_ON_TIMEOUT) || fiveMinutes
+const waitOnInterval =
+  Number(process.env.WAIT_ON_INTERVAL) || twoSeconds
 
 const isDebug = () =>
-  process.env.DEBUG &&
-  process.env.DEBUG.indexOf('start-server-and-test') !== -1
+  process.env.DEBUG?.includes('start-server-and-test')
 
 const isInsecure = () => process.env.START_SERVER_AND_TEST_INSECURE
 


### PR DESCRIPTION
* Replace the ternary env reads with `Number(env) || default`
* Replace `DEBUG.indexOf(...) !== -1` with `DEBUG?.includes(...)`

The only case this changes the behavior AFAICT is when one was using `0`. The old code code passed `0`/`NaN` through. If you consider this a breaking change let me know and I can adapt the patch, but the new one seems a little more logical to me. :)