### PR TITLE
chore: normalize module imports and clean up test files

### DIFF
--- a/src/bin/start.js
+++ b/src/bin/start.js
@@ -1,9 +1,8 @@
 #!/usr/bin/env node
 
 const debug = require('debug')('start-server-and-test')
-
-const startAndTest = require('..').startAndTest
-const utils = require('../utils')
+const { startAndTest } = require('../index.js')
+const utils = require('../utils.js')
 
 const namedArguments = utils.getNamedArguments(process.argv.slice(2))
 debug('named arguments: %o', namedArguments)

--- a/src/start-server-and-test-spec.js
+++ b/src/start-server-and-test-spec.js
@@ -1,7 +1,7 @@
 'use strict'
 
 /* eslint-env mocha */
-const { startAndTest } = require('.')
+const { startAndTest } = require('./index.js')
 
 describe('start-server-and-test', () => {
   it('is a function', () => {

--- a/src/utils-spec.js
+++ b/src/utils-spec.js
@@ -4,6 +4,7 @@
 const { lazyAss: la } = require('lazy-ass')
 const snapshot = require('snap-shot-it')
 const debug = require('debug')('test')
+const utils = require('./utils.js')
 
 function arrayEq(a, b) {
   return (
@@ -12,8 +13,6 @@ function arrayEq(a, b) {
 }
 
 describe('utils', () => {
-  const utils = require('./utils')
-
   context('isPackageScriptName', () => {
     const isPackageScriptName = utils.isPackageScriptName
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,7 +1,7 @@
+const path = require('node:path')
+const { existsSync } = require('node:fs')
 const { lazyAss: la } = require('lazy-ass')
 const is = require('check-more-types')
-const { join } = require('path')
-const { existsSync } = require('fs')
 const arg = require('arg')
 const debug = require('debug')('start-server-and-test')
 
@@ -166,7 +166,7 @@ const isPackageScriptName = (command) => {
     command,
   )
 
-  const packageFilename = join(process.cwd(), 'package.json')
+  const packageFilename = path.join(process.cwd(), 'package.json')
   if (!existsSync(packageFilename)) {
     return false
   }

--- a/test/https-server.js
+++ b/test/https-server.js
@@ -1,13 +1,14 @@
-const https = require('https');
+const fs = require('node:fs')
+const https = require('node:https')
+const path = require('node:path')
 
-var fs = require('fs');
-var path = require('path');
-
-var options = {
+const options = {
   key: fs.readFileSync(path.resolve(__dirname, 'testkey.txt')),
   cert: fs.readFileSync(path.resolve(__dirname, 'test.cert')),
-};
+}
 
-const server = https.createServer(options, (req, res) => res.end('HTTPS is good!\n\n'));
+const server = https.createServer(options, (req, res) => {
+  res.end('HTTPS is good!\n\n')
+})
 
-server.listen(9000);
+server.listen(9000)

--- a/test/ip6.mjs
+++ b/test/ip6.mjs
@@ -1,17 +1,19 @@
-import http from 'node:http';
+import http from 'node:http'
 
 // Create a local server to receive data from
-const server = http.createServer();
+const server = http.createServer()
 
 // Listen to the request event
 server.on('request', (request, res) => {
   console.log('server responding')
-  res.writeHead(200, { 'Content-Type': 'application/json' });
-  res.end(JSON.stringify({
-    data: 'Hello World!',
-  }));
-});
+  res.writeHead(200, { 'Content-Type': 'application/json' })
+  res.end(
+    JSON.stringify({
+      data: 'Hello World!',
+    }),
+  )
+})
 
 server.listen(8000, '::1', () => {
   console.log('server is listening on ::1:8000')
-});
+})

--- a/test/multiple-servers.js
+++ b/test/multiple-servers.js
@@ -1,12 +1,14 @@
-const http = require('http');
+const http = require('node:http')
+
 const server = http.createServer((req, res) => {
   console.log(req.method)
   if (req.method === 'GET') {
     res.end('Server 1 is good!\n\n')
   } else {
-    res.end();
+    res.end()
   }
-});
+})
+
 setTimeout(() => {
   server.listen(9000)
   console.log('listening at port 9000')
@@ -17,9 +19,10 @@ const server2 = http.createServer((req, res) => {
   if (req.method === 'GET') {
     res.end('Server 2 is good!\n\n')
   } else {
-    res.end();
+    res.end()
   }
-});
+})
+
 setTimeout(() => {
   server2.listen(9001)
   console.log('listening at port 9001')

--- a/test/server-304.js
+++ b/test/server-304.js
@@ -1,3 +1,4 @@
+const http = require('node:http')
 const { parseArgs } = require('node:util')
 
 const { values } = parseArgs({
@@ -8,7 +9,8 @@ const { values } = parseArgs({
     },
   },
 })
-const http = require('http')
+const port = Number(values.port) || 9000
+
 const server = http.createServer((req, res) => {
   console.log(req.method)
   if (req.method === 'GET') {
@@ -17,7 +19,7 @@ const server = http.createServer((req, res) => {
     res.end()
   }
 })
-const port = Number(values.port) || 9000
+
 setTimeout(() => {
   server.listen(port)
   console.log('listening at port %d', port)

--- a/test/server-403.js
+++ b/test/server-403.js
@@ -1,3 +1,4 @@
+const http = require('node:http')
 const { parseArgs } = require('node:util')
 
 const { values } = parseArgs({
@@ -8,7 +9,8 @@ const { values } = parseArgs({
     },
   },
 })
-const http = require('http')
+const port = Number(values.port) || 9000
+
 const server = http.createServer((req, res) => {
   if (req.method === 'GET' || req.method === 'HEAD') {
     console.log('%s returning 403', req.method)
@@ -17,9 +19,10 @@ const server = http.createServer((req, res) => {
     res.end()
   }
 })
-const port = Number(values.port) || 9000
+
 setTimeout(() => {
   server.listen(port)
   console.log('listening at port %d, responding with 403', port)
 }, 5000)
+
 console.log('sleeping for 5 seconds before starting')

--- a/test/server-as-child.js
+++ b/test/server-as-child.js
@@ -1,9 +1,13 @@
-const childProcess = require('child_process');
+const childProcess = require('node:child_process')
 
-console.log('Starting server as child process');
+console.log('Starting server as child process')
+
 const result = childProcess.spawnSync(
   'node',
-  [].concat(require.resolve('./server')).concat(process.argv.slice(2)),
-  { stdio: 'inherit' }
-);
-console.log('Done');
+  []
+    .concat(require.resolve('./server'))
+    .concat(process.argv.slice(2)),
+  { stdio: 'inherit' },
+)
+
+console.log('Done')

--- a/test/server-exits-early.js
+++ b/test/server-exits-early.js
@@ -4,7 +4,7 @@
  * A server that starts listening immediately, then exits on its own after a short delay.
  * Used by the alreadyExited E2E test: the server is gone before stopServer() is called, which should NOT cause startAndTest to reject.
  */
-const http = require('http')
+const http = require('node:http')
 
 const PORT = process.env.SERVER_EXITS_EARLY_PORT || 19877
 

--- a/test/server-fail.js
+++ b/test/server-fail.js
@@ -1,13 +1,16 @@
-const http = require('http');
+const http = require('node:http')
+
 const server = http.createServer((req, res) => {
   console.log(req.method)
   if (req.method === 'GET') {
     res.end('All good\n\n')
   } else {
-    res.end();
+    res.end()
   }
-});
+})
+
 setTimeout(() => {
   process.exit(1)
 }, 5000)
+
 console.log('sleeping for 5 seconds before starting')

--- a/test/server.js
+++ b/test/server.js
@@ -1,3 +1,4 @@
+const http = require('node:http')
 const { parseArgs } = require('node:util')
 
 const { values } = parseArgs({
@@ -8,7 +9,8 @@ const { values } = parseArgs({
     },
   },
 })
-const http = require('http')
+const port = Number(values.port) || 9000
+
 const server = http.createServer((req, res) => {
   console.log(req.method)
   if (req.method === 'GET') {
@@ -17,9 +19,10 @@ const server = http.createServer((req, res) => {
     res.end()
   }
 })
-const port = Number(values.port) || 9000
+
 setTimeout(() => {
   server.listen(port)
   console.log('listening at port %d', port)
 }, 5000)
+
 console.log('sleeping for 5 seconds before starting')

--- a/test/zero.mjs
+++ b/test/zero.mjs
@@ -1,17 +1,19 @@
-import http from 'node:http';
+import http from 'node:http'
 
 // Create a local server to receive data from
-const server = http.createServer();
+const server = http.createServer()
 
 // Listen to the request event
 server.on('request', (request, res) => {
   console.log('server responding')
-  res.writeHead(200, { 'Content-Type': 'application/json' });
-  res.end(JSON.stringify({
-    data: 'Hello World!',
-  }));
-});
+  res.writeHead(200, { 'Content-Type': 'application/json' })
+  res.end(
+    JSON.stringify({
+      data: 'Hello World!',
+    }),
+  )
+})
 
 server.listen(8000, '0.0.0.0', () => {
   console.log('server is listening on 0.0.0.0:8000')
-});
+})


### PR DESCRIPTION
* use `node:` prefix for all built‑in module imports
* add explicit `.js` extensions to local imports
* move imports above other declarations where needed
* replace `var` with `const` in test helpers
* reformat test files