### PR TITLE
chore(renovate): set rangeStrategy to bump

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,7 @@
   "updateNotScheduled": false,
   "timezone": "America/New_York",
   "minimumReleaseAge": "7 days",
+  "rangeStrategy": "bump",
   "packageRules": [
     {
       "matchDepTypes": ["devDependencies"],


### PR DESCRIPTION
## Situation

`devDependencies` are defined with a historical mixture of pinned versions and SemVer ranges.

https://github.com/bahmutov/start-server-and-test/blob/e1313c3d4c8d31dd23d7a5ae8f0533f976a51c79/package.json#L91-L102

Renovate now maintains these versions:

https://github.com/bahmutov/start-server-and-test/blob/e1313c3d4c8d31dd23d7a5ae8f0533f976a51c79/renovate.json#L13-L17

using the default [rangeStrategy](https://docs.renovatebot.com/configuration-options/#rangestrategy) of `auto` which in some cases updates only the package manager lockfile.

## Change

Set the Renovate [rangeStrategy](https://docs.renovatebot.com/configuration-options/#rangestrategy) to `bump`.