### PR TITLE
chore(renovate): enable lockfileMaintenance

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,9 @@
   "timezone": "America/New_York",
   "minimumReleaseAge": "7 days",
   "rangeStrategy": "bump",
+  "lockFileMaintenance": {
+    "enabled": true
+  },
   "packageRules": [
     {
       "matchDepTypes": ["devDependencies"],


### PR DESCRIPTION
## Situation

Renovate is currently not configured in [renovate.json](https://github.com/bahmutov/start-server-and-test/blob/master/renovate.json) for `lockfileMaintenance`.

This means that vulnerabilities in transient dependencies are currently not addressed by Renovate updates.

## Change

Enable `lockFileMaintenance` in the [renovate.json](https://github.com/bahmutov/start-server-and-test/blob/master/renovate.json) configuration.

`lockFileMaintenance` runs weekly by default. Maintainers can also initiate it manually through the [Dependency Dashboard](https://github.com/bahmutov/start-server-and-test/issues/458) or through the [Renovate Web UI](https://developer.mend.io/github/bahmutov/start-server-and-test).