### PR TITLE
docs: add Linux ps dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ Requires [Node.js](https://nodejs.org/en/) version 22, 24 or above.
 npm install --save-dev start-server-and-test
 ```
 
+If you are running on Linux, ensure that `ps` is available.
+Minimal Docker images, such as `node:slim`, may not include this by default.
+On Debian, `ps` is included in the `procps` package, which may need to be installed additionally.
+Detailed requirements are listed in the dependency documentation
+[tree-kill > Methods](https://github.com/pkrumins/node-tree-kill#methods).
+
 ## Upgrade
 
 ### v1 to v2


### PR DESCRIPTION
- closes https://github.com/bahmutov/start-server-and-test/issues/281
- closes https://github.com/bahmutov/start-server-and-test/issues/504

## Situation

The [README > Install](https://github.com/bahmutov/start-server-and-test#install) section mentions only the Node.js version requirement. It does not mention any requirements from the dependency [tree-kill](https://www.npmjs.com/package/tree-kill) to be able to kill processes.

These requirements are listed in the [tree-kill > Methods](https://github.com/pkrumins/node-tree-kill#methods) documentation section as follows:

---

## require('tree-kill')(pid, [signal], [callback]);

Sends signal `signal` to all children processes of the process with pid `pid`, including `pid`. Signal defaults to `SIGTERM`.

For Linux, this uses `ps -o pid --no-headers --ppid PID` to find the parent pids of `PID`.

For Darwin/OSX, this uses `pgrep -P PID` to find the parent pids of `PID`.

For Windows, this uses `'taskkill /pid PID /T /F'` to kill the process tree. Note that on Windows, sending the different kinds of POSIX signals is not possible.

---

Minimal Linux systems such as the Docker image [node:slim](https://github.com/nodejs/docker-node#nodeslim) do not include `ps`.

## Change

- Add requirement for `ps` on Linux. Note that on Debian this is included in the package `procps`
- Refer to [tree-kill > Methods](https://github.com/pkrumins/node-tree-kill#methods)